### PR TITLE
Configure release profile to minimize binary size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,5 +35,12 @@ harness = false
 name = "mmdr"
 path = "src/main.rs"
 
+[profile.release]
+strip = true
+lto = "fat"
+opt-level = "z"
+codegen-units = 1
+panic = "abort"
+
 [patch.crates-io]
 dagre_rust = { path = "vendor/dagre_rust" }


### PR DESCRIPTION
This configures the release builds to minimize the binary size. This generally shouldn't have that large of an impact on CPU performance. Though it might be worth investigating it's impact.