### PR TITLE
Fix panic in dagre_rust remove_edge_label_proxies on edge labels

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -339,4 +339,55 @@ mod tests {
         assert!(svg.contains("Dogs"));
         assert!(!svg.contains("Syntax error in text"));
     }
+
+    // Regression tests for dagre_rust edge label proxy crash (unwrap on None)
+    // See: vendor/dagre_rust/src/layout/mod.rs remove_edge_label_proxies()
+
+    #[test]
+    fn test_flowchart_edge_labels() {
+        let svg = render(
+            r#"flowchart LR
+  A([Start]) --> B{Decision}
+  B -->|yes| C[/Do thing/]
+  B -->|no| D[\Skip\]
+  C --> E[[End]]
+  D --> E"#,
+        )
+        .unwrap();
+        assert!(svg.contains("<svg"));
+        assert!(svg.contains("</svg>"));
+    }
+
+    #[test]
+    fn test_state_diagram_with_labels() {
+        let svg = render(
+            r#"stateDiagram-v2
+[*] --> Idle
+Idle --> Active : start
+state "Waiting" as Wait
+Wait --> Active"#,
+        )
+        .unwrap();
+        assert!(svg.contains("<svg"));
+        assert!(svg.contains("</svg>"));
+    }
+
+    #[test]
+    fn test_er_diagram() {
+        let svg = render(
+            r#"erDiagram
+CUSTOMER ||--o{ ORDER : places
+CUSTOMER {
+string id
+string name
+}
+ORDER {
+string id
+date created_at
+}"#,
+        )
+        .unwrap();
+        assert!(svg.contains("<svg"));
+        assert!(svg.contains("</svg>"));
+    }
 }

--- a/vendor/dagre_rust/src/layout/mod.rs
+++ b/vendor/dagre_rust/src/layout/mod.rs
@@ -388,9 +388,11 @@ pub fn remove_edge_label_proxies(g: &mut Graph<GraphConfig, GraphNode, GraphEdge
     let node = g.node(v).unwrap();
     if node.dummy.is_some() && node.dummy.clone().unwrap() == "edge-proxy" {
       let rank = node.rank.unwrap_or(0);
-      let graph_edge_ = g.edge_mut_with_obj(&node.e.clone().unwrap());
-      if let Some(graph_edge) = graph_edge_ {
-        graph_edge.label_rank = Some(rank);
+      if let Some(edge_ref) = node.e.clone() {
+        let graph_edge_ = g.edge_mut_with_obj(&edge_ref);
+        if let Some(graph_edge) = graph_edge_ {
+          graph_edge.label_rank = Some(rank);
+        }
       }
       g.remove_node(v);
     }


### PR DESCRIPTION
Fix panic in dagre_rust remove_edge_label_proxies on edge labels

remove_edge_label_proxies() in dagre_rust unconditionally unwraps node.e, which can be None by the time the function runs. The layout pipeline calls nesting_graph::cleanup() between inject_edge_label_proxies and remove_edge_label_proxies, which removes the nesting root node and its incident edges -- this can invalidate the edge reference stored on dummy proxy nodes.

This causes a panic on any diagram that produces edge label proxies during layout:                                                    
- Flowcharts with edge labels (-->|label|) or diamond decision nodes ({...})                                                          
- State diagrams with transition labels (: event)                                                                                     
- ER diagrams with relationship labels                                                                                                
                                                                                                                                        
The fix replaces the unwrap() with if let Some(...), so a missing edge ref is skipped rather than crashing. The node is still removed from the graph regardless.

Includes regression tests for all three crash cases.

(I didn't do any of this, just forked the repo and asked my AI-agent do fix the bug I / we found while I worked on other stuff)