### PR TITLE
Fix unescaped font-family quotes in SVG output

### DIFF
--- a/src/render.rs
+++ b/src/render.rs
@@ -2380,7 +2380,7 @@ fn render_pie(pie: &PieData, theme: &Theme, config: &LayoutConfig) -> String {
             label_x,
             label.y,
             anchor,
-            theme.font_family,
+            escape_xml(&theme.font_family),
             label.font_size,
             escape_xml(&theme.pie_section_text_color),
             label.text
@@ -2575,7 +2575,7 @@ fn render_quadrant(
             grid_y + half_h + half_h / 2.0,
             grid_x - 15.0,
             grid_y + half_h + half_h / 2.0,
-            theme.font_family,
+            escape_xml(&theme.font_family),
             theme.font_size,
             y_bottom.lines.first().map(|s| s.as_str()).unwrap_or("")
         ));
@@ -2587,7 +2587,7 @@ fn render_quadrant(
             grid_y + half_h / 2.0,
             grid_x - 15.0,
             grid_y + half_h / 2.0,
-            theme.font_family,
+            escape_xml(&theme.font_family),
             theme.font_size,
             y_top.lines.first().map(|s| s.as_str()).unwrap_or("")
         ));
@@ -3387,7 +3387,7 @@ fn render_gitgraph(gitgraph: &GitGraphLayout, theme: &Theme, config: &LayoutConf
                 "<text x=\"{:.2}\" y=\"{:.2}\" text-anchor=\"start\" font-family=\"{}\" font-size=\"{}\" fill=\"{}\">{}</text>",
                 label.text_x,
                 label.text_y,
-                theme.font_family,
+                escape_xml(&theme.font_family),
                 gg.commit_label_font_size,
                 escape_xml(&theme.git_commit_label_color),
                 escape_xml(&label.text)
@@ -3433,7 +3433,7 @@ fn render_gitgraph(gitgraph: &GitGraphLayout, theme: &Theme, config: &LayoutConf
                     "<text x=\"{:.2}\" y=\"{:.2}\" text-anchor=\"start\" font-family=\"{}\" font-size=\"{}\" fill=\"{}\">{}</text>",
                     tag.text_x,
                     tag.text_y,
-                    theme.font_family,
+                    escape_xml(&theme.font_family),
                     gg.tag_label_font_size,
                     escape_xml(&theme.git_tag_label_color),
                     escape_xml(&tag.text)
@@ -3560,7 +3560,7 @@ fn text_block_svg_with_font_size(
 
     text.push_str(&format!(
         "<text x=\"{x:.2}\" y=\"{start_y:.2}\" text-anchor=\"{anchor}\" font-family=\"{}\" font-size=\"{}\" fill=\"{}\">",
-        theme.font_family,
+        escape_xml(&theme.font_family),
         font_size,
         fill
     ));
@@ -3611,7 +3611,7 @@ fn text_block_svg_with_font_size_weight(
 
     text.push_str(&format!(
         "<text x=\"{x:.2}\" y=\"{start_y:.2}\" text-anchor=\"{anchor}\" font-family=\"{}\" font-size=\"{}\" fill=\"{}\"{weight_attr}>",
-        theme.font_family,
+        escape_xml(&theme.font_family),
         font_size,
         fill
     ));
@@ -3645,7 +3645,7 @@ fn text_line_svg_with_font_size(
 ) -> String {
     format!(
         "<text x=\"{x:.2}\" y=\"{y:.2}\" text-anchor=\"{anchor}\" font-family=\"{}\" font-size=\"{}\" fill=\"{}\">{}</text>",
-        theme.font_family,
+        escape_xml(&theme.font_family),
         font_size,
         fill,
         escape_xml(text)
@@ -3655,7 +3655,7 @@ fn text_line_svg_with_font_size(
 fn text_line_svg(x: f32, y: f32, text: &str, theme: &Theme, fill: &str, anchor: &str) -> String {
     format!(
         "<text x=\"{x:.2}\" y=\"{y:.2}\" text-anchor=\"{anchor}\" font-family=\"{}\" font-size=\"{}\" fill=\"{}\">{}</text>",
-        theme.font_family,
+        escape_xml(&theme.font_family),
         theme.font_size,
         fill,
         escape_xml(text)
@@ -4413,7 +4413,7 @@ fn render_er_node_label(
                     "<text x=\"{:.2}\" y=\"{:.2}\" text-anchor=\"start\" font-family=\"{}\" font-size=\"{}\" fill=\"{}\" fill-opacity=\"0.75\">{}</text>",
                     left_x,
                     y,
-                    theme.font_family,
+                    escape_xml(&theme.font_family),
                     theme.font_size,
                     fill,
                     escape_xml(&ty)
@@ -4422,7 +4422,7 @@ fn render_er_node_label(
                     "<text x=\"{:.2}\" y=\"{:.2}\" text-anchor=\"start\" font-family=\"{}\" font-size=\"{}\" fill=\"{}\">{}</text>",
                     name_x,
                     y,
-                    theme.font_family,
+                    escape_xml(&theme.font_family),
                     theme.font_size,
                     fill,
                     escape_xml(&name)
@@ -4462,7 +4462,7 @@ fn text_lines_svg(
     let mut text = String::new();
     text.push_str(&format!(
         "<text x=\"{x:.2}\" y=\"{first_y:.2}\" text-anchor=\"{anchor}\" font-family=\"{}\" font-size=\"{}\" fill=\"{}\">",
-        theme.font_family,
+        escape_xml(&theme.font_family),
         theme.font_size,
         fill
     ));
@@ -4618,7 +4618,7 @@ fn er_badge_svg(
         "<text x=\"{:.2}\" y=\"{:.2}\" text-anchor=\"middle\" font-family=\"{}\" font-size=\"{:.2}\" font-weight=\"600\" fill=\"{}\">{}</text>",
         x + width / 2.0,
         y + font_size * 0.26,
-        font_family,
+        escape_xml(font_family),
         font_size * 0.72,
         text_color,
         escape_xml(text)


### PR DESCRIPTION
Font families containing quotes (e.g. "Segoe UI") were interpolated directly into SVG font-family attributes without XML escaping, producing invalid XML. Handles it by adding `escape_xml()`.