### PR TITLE
Fix: index-out-of-bounds panic in build_subgraph_layouts when a subgraph has no positioned nodes

### DIFF
--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -5287,6 +5287,8 @@ fn build_subgraph_layouts(
     config: &LayoutConfig,
 ) -> Vec<SubgraphLayout> {
     let mut subgraphs = Vec::new();
+    // Maps graph.subgraphs index -> local subgraphs index (None if skipped).
+    let mut graph_to_local: Vec<Option<usize>> = Vec::with_capacity(graph.subgraphs.len());
     for sub in &graph.subgraphs {
         let mut min_x = f32::MAX;
         let mut min_y = f32::MAX;
@@ -5303,6 +5305,7 @@ fn build_subgraph_layouts(
         }
 
         if min_x == f32::MAX {
+            graph_to_local.push(None);
             continue;
         }
 
@@ -5326,6 +5329,7 @@ fn build_subgraph_layouts(
         let width = base_width.max(min_label_width);
         let extra_width = width - base_width;
 
+        graph_to_local.push(Some(subgraphs.len()));
         subgraphs.push(SubgraphLayout {
             label: sub.label.clone(),
             label_block,
@@ -5341,14 +5345,16 @@ fn build_subgraph_layouts(
 
     if subgraphs.len() > 1 {
         let tree = SubgraphTree::build(graph);
+        let n = graph.subgraphs.len();
 
         // Collect all descendants for each subgraph via the tree so we only
         // visit actual parent-child pairs instead of every O(n²) combination.
         // Process from leaves up so that child bounds are final before parents
         // expand to contain them.
-        let mut all_descendants: Vec<Vec<usize>> = vec![Vec::new(); subgraphs.len()];
+        // Size by graph.subgraphs.len() so tree indices (graph-level) are valid.
+        let mut all_descendants: Vec<Vec<usize>> = vec![Vec::new(); n];
         // Post-order traversal: collect leaves first, then parents.
-        let mut order: Vec<usize> = Vec::with_capacity(subgraphs.len());
+        let mut order: Vec<usize> = Vec::with_capacity(n);
         let mut stack: Vec<(usize, bool)> =
             tree.top_level.iter().rev().map(|&i| (i, false)).collect();
         while let Some((idx, visited)) = stack.pop() {
@@ -5373,21 +5379,25 @@ fn build_subgraph_layouts(
         }
 
         // Expand each parent's bounds to contain all its descendants.
+        // Use graph_to_local to translate graph-level indices to local indices,
+        // skipping any subgraph that was filtered out (no positioned nodes).
         for &i in &order {
+            let Some(local_i) = graph_to_local[i] else { continue };
             for &j in &all_descendants[i] {
                 if is_region_subgraph(&graph.subgraphs[j]) {
                     continue;
                 }
+                let Some(local_j) = graph_to_local[j] else { continue };
                 let pad = if graph.kind == crate::ir::DiagramKind::State {
                     (theme.font_size * 1.8).max(24.0)
                 } else {
                     12.0
                 };
                 let (child_x, child_y, child_w, child_h) = {
-                    let child = &subgraphs[j];
+                    let child = &subgraphs[local_j];
                     (child.x, child.y, child.width, child.height)
                 };
-                let parent = &mut subgraphs[i];
+                let parent = &mut subgraphs[local_i];
                 let min_x = parent.x.min(child_x - pad);
                 let min_y = parent.y.min(child_y - pad);
                 let max_x = (parent.x + parent.width).max(child_x + child_w + pad);

--- a/tests/fixtures/flowchart/subgraph_empty.mmd
+++ b/tests/fixtures/flowchart/subgraph_empty.mmd
@@ -1,0 +1,20 @@
+flowchart TD
+    subgraph ROW1["Input"]
+        direction LR
+        A["Node A"]
+        B["Node B"]
+    end
+    subgraph ROW2["Processing"]
+        direction LR
+        C["Node C"]
+        D["Node D"]
+    end
+    subgraph ROW3["Annotations"]
+        direction LR
+        NOTE1("This subgraph has only\nannotation nodes that\nhave no positioned peers")
+        NOTE2("Another annotation\nwithout a main node")
+        NOTE1 -.- NOTE2
+    end
+    A --> C
+    B --> D
+    NOTE1 -.- A

--- a/tests/layout_suite.rs
+++ b/tests/layout_suite.rs
@@ -39,6 +39,7 @@ fn render_all_fixtures() {
         "flowchart/styles.mmd",
         "flowchart/subgraph.mmd",
         "flowchart/subgraph_direction.mmd",
+        "flowchart/subgraph_empty.mmd",
         "flowchart/cycles.mmd",
         "gantt/basic.mmd",
         "gitgraph/basic.mmd",


### PR DESCRIPTION

Reproducer: https://dpaste.com/73QG5X9QM

## Root Cause

`build_subgraph_layouts` builds a local `subgraphs` vec by iterating over
`graph.subgraphs` and **skipping** any subgraph whose nodes have no layout
positions yet. However, `SubgraphTree` is built directly from `graph.subgraphs`
and its indices refer to positions in that full list. When any subgraph is
filtered out, the two index spaces diverge, causing an out-of-bounds access in
the parent-bounds expansion loop.

## Fix

- Build a `graph_to_local: Vec<Option<usize>>` mapping during the filter pass
- Size `all_descendants` by `graph.subgraphs.len()` so `SubgraphTree` indices
  are always valid
- In the bounds-expansion loop, translate graph-level indices through
  `graph_to_local` and skip `None` entries (filtered-out subgraphs)

## Testing

Added `tests/fixtures/flowchart/subgraph_empty.mmd` — a flowchart with a
subgraph containing only annotation nodes (no positioned peers). This fixture
panics on the unpatched code and passes cleanly after the fix. It is registered
in `tests/layout_suite.rs` as a permanent regression guard.