### PR TITLE
class: Fix arrowheads hidden under node boxes

### DIFF
--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -1130,6 +1130,19 @@ fn compute_flowchart_layout(
                 .and_then(|plan| plan.as_ref())
                 .map(|plan| plan.center)
         };
+        let (start_inset, end_inset) = {
+            let start = if edge.arrow_start {
+                crate::render::arrowhead_inset(graph.kind, edge.arrow_start_kind)
+            } else {
+                0.0
+            };
+            let end = if edge.arrow_end {
+                crate::render::arrowhead_inset(graph.kind, edge.arrow_end_kind)
+            } else {
+                0.0
+            };
+            (start, end)
+        };
         let route_ctx = RouteContext {
             from_id: &edge.from,
             to_id: &edge.to,
@@ -1146,6 +1159,8 @@ fn compute_flowchart_layout(
             start_offset: port_info.start_offset,
             end_offset: port_info.end_offset,
             stub_len,
+            start_inset,
+            end_inset,
             prefer_shorter_ties: !avoid_short_tie,
             preferred_label_id,
             preferred_label_center,
@@ -1185,6 +1200,8 @@ fn compute_flowchart_layout(
                 start_offset: route_ctx.start_offset,
                 end_offset: route_ctx.end_offset,
                 stub_len: route_ctx.stub_len,
+                start_inset: route_ctx.start_inset,
+                end_inset: route_ctx.end_inset,
                 prefer_shorter_ties: route_ctx.prefer_shorter_ties,
                 preferred_label_id: route_ctx.preferred_label_id,
                 preferred_label_center: route_ctx.preferred_label_center,
@@ -5793,6 +5810,8 @@ mod tests {
             end_offset: 0.0,
             fast_route: false,
             stub_len: port_stub_length(&config, &from, &to),
+            start_inset: 0.0,
+            end_inset: 0.0,
             prefer_shorter_ties: true,
             preferred_label_id: None,
             preferred_label_center: None,
@@ -5834,6 +5853,8 @@ mod tests {
             end_offset: 0.0,
             fast_route: false,
             stub_len: port_stub_length(&config, &from, &to),
+            start_inset: 0.0,
+            end_inset: 0.0,
             prefer_shorter_ties: true,
             preferred_label_id: None,
             preferred_label_center: None,
@@ -5875,6 +5896,8 @@ mod tests {
             end_offset: 0.0,
             fast_route: false,
             stub_len: port_stub_length(&config, &from, &to),
+            start_inset: 0.0,
+            end_inset: 0.0,
             prefer_shorter_ties: true,
             preferred_label_id: None,
             preferred_label_center: None,
@@ -5941,6 +5964,8 @@ mod tests {
             end_offset: 0.0,
             fast_route: false,
             stub_len: port_stub_length(&config, &from, &to),
+            start_inset: 0.0,
+            end_inset: 0.0,
             prefer_shorter_ties: true,
             preferred_label_id: Some("edge-label-reserved:0"),
             preferred_label_center: Some(preferred),

--- a/src/layout/routing.rs
+++ b/src/layout/routing.rs
@@ -354,6 +354,8 @@ pub(super) struct RouteContext<'a> {
     pub(super) start_offset: f32,
     pub(super) end_offset: f32,
     pub(super) stub_len: f32,
+    pub(super) start_inset: f32,
+    pub(super) end_inset: f32,
     pub(super) prefer_shorter_ties: bool,
     pub(super) preferred_label_id: Option<&'a str>,
     pub(super) preferred_label_center: Option<(f32, f32)>,
@@ -1165,6 +1167,37 @@ pub(super) fn path_coords_reasonable(points: &[(f32, f32)]) -> bool {
         .all(|(x, y)| x.is_finite() && y.is_finite() && x.abs() <= LIMIT && y.abs() <= LIMIT)
 }
 
+fn apply_endpoint_insets(
+    mut path: Vec<(f32, f32)>,
+    start_inset: f32,
+    end_inset: f32,
+) -> Vec<(f32, f32)> {
+    if start_inset > 0.0 && path.len() >= 2 {
+        let (sx, sy) = path[0];
+        let (nx, ny) = path[1];
+        let dx = sx - nx;
+        let dy = sy - ny;
+        let len = (dx * dx + dy * dy).sqrt();
+        if len > start_inset {
+            let r = start_inset / len;
+            path[0] = (sx - dx * r, sy - dy * r);
+        }
+    }
+    if end_inset > 0.0 && path.len() >= 2 {
+        let n = path.len();
+        let (px, py) = path[n - 2];
+        let (ex, ey) = path[n - 1];
+        let dx = ex - px;
+        let dy = ey - py;
+        let len = (dx * dx + dy * dy).sqrt();
+        if len > end_inset {
+            let r = end_inset / len;
+            path[n - 1] = (ex - dx * r, ey - dy * r);
+        }
+    }
+    path
+}
+
 fn point_segment_distance(a: (f32, f32), b: (f32, f32), p: (f32, f32)) -> f32 {
     let vx = b.0 - a.0;
     let vy = b.1 - a.1;
@@ -1366,7 +1399,7 @@ pub(super) fn route_edge_with_avoidance(
 
         let mut best = compress_path(&candidates.swap_remove(best_idx));
         enforce_preferred_label_via(&mut best, ctx);
-        return compress_path(&best);
+        return apply_endpoint_insets(compress_path(&best), ctx.start_inset, ctx.end_inset);
     }
 
     let (_, _, is_backward) = edge_sides(ctx.from, ctx.to, ctx.direction);
@@ -1399,7 +1432,7 @@ pub(super) fn route_edge_with_avoidance(
     if ctx.fast_route {
         let mut fast = compress_path(&[start, route_start, route_end, end]);
         enforce_preferred_label_via(&mut fast, ctx);
-        return compress_path(&fast);
+        return apply_endpoint_insets(compress_path(&fast), ctx.start_inset, ctx.end_inset);
     }
     let mut candidates: Vec<Vec<(f32, f32)>> = Vec::new();
     let mut intersections: Vec<usize> = Vec::new();
@@ -1996,7 +2029,7 @@ pub(super) fn route_edge_with_avoidance(
         combined.extend(candidates.swap_remove(best_idx));
         combined.push(end);
         enforce_preferred_label_via(&mut combined, ctx);
-        return compress_path(&combined);
+        return apply_endpoint_insets(compress_path(&combined), ctx.start_inset, ctx.end_inset);
     }
 
     let mut best_idx = 0usize;
@@ -2084,7 +2117,7 @@ pub(super) fn route_edge_with_avoidance(
     combined.extend(candidates.swap_remove(best_idx));
     combined.push(end);
     enforce_preferred_label_via(&mut combined, ctx);
-    compress_path(&combined)
+    apply_endpoint_insets(compress_path(&combined), ctx.start_inset, ctx.end_inset)
 }
 
 pub(super) fn path_obstacle_intersections(

--- a/src/render.rs
+++ b/src/render.rs
@@ -44,6 +44,26 @@ fn edge_dom_id(edge_idx: usize) -> String {
     format!("edge-{edge_idx}")
 }
 
+/// How many pixels the arrowhead marker penetrates past the path endpoint.
+/// Must stay in sync with the `<marker>` definitions in [`render_svg`].
+///
+/// - `OpenTriangle`: refX=1, base at x=18 -> 17 px
+/// - `ClassDependency`: refX=13, shape max x=18 -> 5 px
+/// - Generic: viewBox 10, markerWidth 8, refX=5 -> (10-5)*(8/10) = 4 px
+pub fn arrowhead_inset(
+    kind: crate::ir::DiagramKind,
+    arrow_kind: Option<crate::ir::EdgeArrowhead>,
+) -> f32 {
+    match kind {
+        crate::ir::DiagramKind::Class => match arrow_kind {
+            Some(crate::ir::EdgeArrowhead::OpenTriangle) => 17.0,
+            Some(crate::ir::EdgeArrowhead::ClassDependency) => 5.0,
+            None => 4.0,
+        },
+        _ => 0.0,
+    }
+}
+
 pub fn render_svg(layout: &Layout, theme: &Theme, config: &LayoutConfig) -> String {
     let mut svg = String::new();
     let state_font_size = if layout.kind == crate::ir::DiagramKind::State {


### PR DESCRIPTION
Issue: https://github.com/zed-industries/zed/issues/50238

Release Notes:

- Fixed class diagram arrowheads rendering underneath node boxes.