### PR TITLE
render: Make dotted edges visually distinct

### DIFF
--- a/src/render.rs
+++ b/src/render.rs
@@ -937,7 +937,7 @@ pub fn render_svg(layout: &Layout, theme: &Theme, config: &LayoutConfig) -> Stri
             let (mut dash, mut stroke_width) = match edge.style {
                 crate::ir::EdgeStyle::Solid => (String::new(), base_edge_width),
                 crate::ir::EdgeStyle::Dotted => {
-                    ("stroke-dasharray=\"2\"".to_string(), base_edge_width)
+                    ("stroke-dasharray=\"4 4\"".to_string(), base_edge_width)
                 }
                 crate::ir::EdgeStyle::Thick => (String::new(), 3.5),
             };


### PR DESCRIPTION
Issue: https://github.com/zed-industries/zed/issues/50238

Release Notes:

- Fixed dotted edges rendering too similarly to solid edges.