### PR TITLE
Fix panic in sequence diagram when alt label is wider than frame

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -532,7 +532,7 @@ dependencies = [
 
 [[package]]
 name = "mermaid-rs-renderer"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/src/layout/sequence.rs
+++ b/src/layout/sequence.rs
@@ -379,12 +379,14 @@ pub(super) fn compute_sequence_layout(
                         let min_x = frame_x + block.width / 2.0 + theme.font_size * 0.4;
                         let max_x =
                             frame_x + frame_width - block.width / 2.0 - theme.font_size * 0.4;
-                        preferred.clamp(min_x, max_x)
+                        // When the label is wider than the frame, min_x > max_x;
+                        // fall back to the midpoint to avoid a clamp panic.
+                        if min_x <= max_x { preferred.clamp(min_x, max_x) } else { (min_x + max_x) / 2.0 }
                     } else {
                         let preferred = frame_x + side_pad + block.width / 2.0;
                         let min_x = frame_x + block.width / 2.0 + side_pad;
                         let max_x = frame_x + frame_width - block.width / 2.0 - side_pad;
-                        preferred.clamp(min_x, max_x)
+                        if min_x <= max_x { preferred.clamp(min_x, max_x) } else { (min_x + max_x) / 2.0 }
                     };
                     section_labels.push(SequenceLabel {
                         x: label_x,

--- a/tests/fixtures/sequence/nested_alt.mmd
+++ b/tests/fixtures/sequence/nested_alt.mmd
@@ -1,0 +1,37 @@
+sequenceDiagram
+    participant C as Client
+    participant API as REST API
+    participant W as Worker
+    participant DB as Database
+    participant R as Redis
+    participant S3
+    participant Q as Queue
+    participant DLQ as Dead Letter Queue
+
+    alt Application error (API failure)
+        Note over W: Exception in pipeline
+        W->>S3: PutObject (error_detail.json)
+        W->>DB: status=FAILED, s3_error_key
+        W->>R: PUBLISH failed
+        R-->>API: Event
+        API-->>C: SSE event: failed {error}
+        W->>Q: DeleteMessage
+        Note over DLQ: Does not reach DLQ
+    end
+
+    alt Infrastructure failure (OOM / crash)
+        Note over W: Worker stopped (status=IN_PROGRESS)
+        Note over Q: visibilityTimeout (360s) elapsed
+        Note over Q: maxReceiveCount (3) exceeded
+        Q->>DLQ: Move message
+        Note over DLQ: CloudWatch Alarm fires (DLQ depth > 0)
+    end
+
+    C->>API: GET /jobs/:id/stream (reconnect)
+    API->>DB: GetItem(job_id)
+    alt COMPLETED / FAILED
+        API->>S3: GetObject
+        API-->>C: Return result, close SSE
+    else IN_PROGRESS
+        Note over API: SUBSCRIBE, re-check, resume waiting
+    end

--- a/tests/layout_suite.rs
+++ b/tests/layout_suite.rs
@@ -53,6 +53,7 @@ fn render_all_fixtures() {
         "sankey/basic.mmd",
         "sequence/basic.mmd",
         "sequence/frames.mmd",
+        "sequence/nested_alt.mmd",
         "state/basic.mmd",
         "state/note.mmd",
         "timeline/basic.mmd",


### PR DESCRIPTION
Release Notes:

- Fixed a panic when rendering sequence diagrams with multiple `alt`/`else` blocks and many participants.

---

Related: #37

When the section label is wider than the containing `alt` frame, `min_x > max_x` in the `clamp()` call at `src/layout/sequence.rs`, causing `f32::clamp()` to panic:

```
min > max, or either was NaN. min = 1488.3577, max = 1460.1311
```

This falls back to the midpoint `(min_x + max_x) / 2.0` when bounds are inverted. A regression test fixture (`sequence/nested_alt.mmd`) is included.