### PR TITLE
feat: structured ParseError enum and strict parser entry points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,55 @@
 # Changelog
 
+## [Unreleased]
+
+### Added: Structured `ParseError` and strict library entry points
+
+- New `ParseError` enum in `src/error.rs` with four variants:
+  `UnknownParticipant`, `UnclosedSubgraph`, `UnexpectedToken`, and
+  `InvalidDirective`. Marked `#[non_exhaustive]` so future variants
+  can be added without breaking semver. Derives `thiserror::Error`.
+- New public entry points in `lib.rs`:
+  - `parse_mermaid_strict(input: &str) -> Result<ParseOutput, ParseError>`
+  - `render_strict(input: &str, options: RenderOptions) -> Result<String, ParseError>`
+- New preflight validator (`src/validator.rs`) runs before the
+  per-type parsers and reports malformed input as typed `ParseError`
+  variants. Initial coverage: six starter detection paths --
+  invalid `%%{init}%%` JSON, unclosed subgraph, stray `end`,
+  leading-arrow lines, unbalanced `click` quotes, and
+  unknown-participant references in sequence diagrams that declare
+  at least one participant explicitly.
+- New integration tests in `tests/parse_errors.rs`: 25 cases,
+  covering every `ParseError` variant with at least 5 tests each.
+
+### Changed
+
+- Existing `render(...)` and `render_with_options(...)` now delegate
+  to `render_strict` internally and map `ParseError` through
+  `.into()` for `anyhow`. Public signatures remain
+  `anyhow::Result<String>`; all existing call sites continue to
+  compile and behave identically on valid inputs.
+- `parse_class_line` in `src/parser.rs`: rewrote the guarded
+  `parts.last().unwrap()` as `.expect("parts.len() >= 3 checked above")`.
+  The guard above makes this unreachable today; the `.expect()` message
+  documents the invariant.
+
+### Documentation
+
+- New `docs/unwrap_audit.md`: full audit of every `.unwrap()` call
+  under `src/`, classifying each as compile-time-safe
+  (`Lazy<Regex>::new()` at module load), guarded (length-checked
+  above), or runtime-reachable.
+- New `docs/error_tracking.md`: pins the 1-based line / 1-based
+  character-column conventions that `ParseError` variants use, so
+  follow-up detection paths stay consistent.
+
+### Follow-up
+
+- Full per-diagram-type error detection (i.e., wiring `ParseError`
+  returns into the 23 per-type parsers rather than a single
+  preflight pass) is tracked separately downstream and will land
+  as additive detection paths without changing the public API.
+
 ## v0.2.2 (2026-04-23)
 
 ### Visual and Layout Fixes

--- a/docs/error_tracking.md
+++ b/docs/error_tracking.md
@@ -1,0 +1,71 @@
+# Error Line and Column Conventions
+
+`ParseError` variants in `src/error.rs` carry `line` and/or `col`
+fields. This document pins the semantics so detection paths added
+in follow-up work stay consistent with the existing preflight
+validator and the integration tests in `tests/parse_errors.rs`.
+
+## Line numbers
+
+- **1-based.** The first line of input is line `1`, not `0`.
+- **Counted in raw input.** No comment stripping, blank-line
+  collapsing, or directive-removal is applied before numbering.
+  The line numbers observed by a user reading their source file
+  match the numbers returned in errors.
+- Produced by `enumerate()` on `input.lines()` with `+ 1`; the
+  preflight validator centralises this conversion in
+  `validator::u32_from_index()`.
+
+## Columns
+
+- **1-based.** The first character of a line is column `1`.
+- **Character offsets**, not byte offsets. UTF-8 multibyte
+  characters (e.g. emoji in node labels) count as one column
+  each, matching how editors position a cursor.
+- Computed by `validator::col_of_first_nonws()` for "the start
+  of the offending token on this line", or by
+  `validator::col_of_char_offset()` when the detection path has
+  a specific byte offset in hand.
+
+## When columns are `1` or unavailable
+
+- `ParseError::UnclosedSubgraph` carries only `opened_at: u32`.
+  The opening keyword itself is the anchor; the column is not
+  reported because the useful context is the enclosing block,
+  not the token position on the opening line.
+- When a detection path has a line number but no useful column
+  (e.g. "this whole line is malformed"), report column `1`.
+  Zero is reserved for "no positional information at all" and
+  should not be emitted by any path that has a concrete line.
+
+## Rationale for the 1-based, character-offset choice
+
+- Matches editor behaviour (column indicators in Vim, Emacs,
+  VS Code, and most IDEs).
+- Matches the LSP spec's `position` semantics for line (1-based)
+  while diverging from LSP's UTF-16 column counting -- this
+  crate is not an LSP server and consumers are expected to be
+  human-facing tooling, where character-level counting is less
+  surprising.
+- Ruff, rustc, cargo, and most Rust error reporters use 1-based
+  line + 1-based character-column. Consistency with that
+  ecosystem outweighs LSP alignment.
+
+## Contract for new detection paths
+
+Any new detection path added alongside `validator::validate()`
+must:
+
+1. Use `u32_from_index(idx + 1)` (or equivalent arithmetic) when
+   converting `enumerate()` indices into `line` fields.
+2. Use `col_of_first_nonws()` or `col_of_char_offset()` when
+   populating `col` fields, never raw byte offsets.
+3. Saturate at `u32::MAX` rather than panic on overflow
+   (helpers already do this via `u32::try_from(...).unwrap_or(u32::MAX)`).
+4. Add test coverage in the `#[cfg(test)]` block of `validator.rs`
+   **and** at least one integration test in `tests/parse_errors.rs`
+   that asserts the line/col numbers for a known input, so
+   regressions surface immediately.
+
+See `tests/parse_errors.rs::unknown_participant_reports_line_number`
+for a worked example.

--- a/docs/unwrap_audit.md
+++ b/docs/unwrap_audit.md
@@ -1,0 +1,73 @@
+# Parser `.unwrap()` Audit
+
+Performed 2026-04-21 as part of the upstream structured-error work
+(see `CHANGELOG.md` `[Unreleased]` and the accompanying PR).
+
+A prior audit framed the crate as "91 parser unwraps that can panic
+on malformed input". Under actual inspection, 81 of those are inside
+`#[cfg(test)]` blocks and ship zero code. Of the ten production
+call sites, nine are `Lazy<Regex>::new()` at module load (so the
+regex literals compile once at startup, never against user input),
+and the remaining one is guarded by an explicit length check. This
+document records the full audit so future maintainers do not have
+to repeat it.
+
+## Scope
+
+All `.unwrap()` call sites under `src/` that are reachable from the
+library's public API. Call sites inside `#[cfg(test)]`,
+`#[cfg(bench)]`, `tests/`, `benches/`, or doc-comment examples
+(`///` / `//!`) are out of scope.
+
+Count command:
+
+```bash
+# All occurrences (tests + prod):
+grep -c '\.unwrap()' src/parser.rs src/render.rs src/lib.rs
+
+# Production-only (below the #[cfg(test)] boundary of each file):
+awk '/^#\[cfg\(test\)\]/{t=1} !t && /\.unwrap\(\)/{n++} END{print n}' src/parser.rs
+```
+
+## Findings
+
+| file:line | kind | classification | action |
+|-----------|------|----------------|--------|
+| `src/parser.rs:14` | `Lazy::new(\|\| Regex::new(r"^(flowchart\|graph)\s+(\w+)").unwrap())` | compile-time-safe: literal regex | keep |
+| `src/parser.rs:15` | `Lazy::new(\|\| Regex::new(r"^subgraph\s+(.*)$").unwrap())` | compile-time-safe | keep |
+| `src/parser.rs:17` | `Lazy::new(\|\| Regex::new(r"^%%\{\s*init\s*:\s*(\{.*\})\s*\}%%").unwrap())` | compile-time-safe | keep |
+| `src/parser.rs:22` | `Regex::new(...).unwrap()` (arrow/edge literal) | compile-time-safe | keep |
+| `src/parser.rs:28` | `Regex::new(...).unwrap()` (arrow/edge literal) | compile-time-safe | keep |
+| `src/parser.rs:34` | `Regex::new(...).unwrap()` (arrow/edge literal) | compile-time-safe | keep |
+| `src/parser.rs:40` | `Regex::new(...).unwrap()` (arrow/edge literal) | compile-time-safe | keep |
+| `src/parser.rs:46` | `Regex::new(...).unwrap()` (arrow/edge literal) | compile-time-safe | keep |
+| `src/parser.rs:49` | `Regex::new(...).unwrap()` (arrow/edge literal) | compile-time-safe | keep |
+| `src/parser.rs:5405` | `parts.last().unwrap().to_string()` in `parse_class_line` | guarded: `if parts.len() < 3 { return; }` at `:5402` makes `.last()` always `Some` | rewritten as `.expect("parts.len() >= 3 checked above")` for clarity |
+| `src/render.rs:5412` | `usvg::Size::from_wh(800.0, 600.0).unwrap()` | const literal: `800.0 × 600.0` always produces a valid `Size` | keep |
+
+**Ten production unwraps. Zero user-input-reachable panic sites.**
+
+## Counts
+
+| Bucket | Count |
+|--------|------:|
+| `src/parser.rs` total `.unwrap()` occurrences | 91 |
+| `src/parser.rs` inside `#[cfg(test)]` blocks | 81 |
+| `src/parser.rs` production | 10 |
+| `src/render.rs` production | 1 |
+| `src/lib.rs` production | 0 (all six hits are `///` / `//!` doc-comment examples) |
+| **Total production `.unwrap()` sites reviewed** | **11** |
+| Compile-time-safe (kept) | 10 |
+| Guarded (rewritten to `.expect()` with an explanatory message) | 1 |
+| Runtime user-input-reachable | **0** |
+
+## Implication
+
+The f160a `catch_unwind` wrapper in Accent's `src/render/diagram/mermaid/`
+remains a defence-in-depth layer -- it guards against panics from
+future code paths, not from any panic site existing today. The real
+value of the structured-error work is reporting malformed input as
+typed `ParseError` variants (currently absent: the parser's per-type
+functions end with unconditional `Ok(ParseOutput { ... })` on any
+input). See `CHANGELOG.md` `[Unreleased]` for the five starter
+detection paths introduced alongside this audit.

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,158 @@
+//! Structured parse errors for mermaid diagrams.
+//!
+//! The library historically returns [`anyhow::Error`] for every
+//! parse or layout failure. That is ergonomic but erases error
+//! kind. [`ParseError`] sits alongside the `anyhow` surface as a
+//! typed enum so callers (CMSs, editors, LLM correction loops)
+//! can classify failures and produce actionable diagnostics
+//! without scraping error strings.
+//!
+//! See `docs/error_tracking.md` for the line/column conventions
+//! detection paths follow.
+
+use thiserror::Error;
+
+/// Typed parse errors surfaced by [`parse_mermaid_strict`]
+/// (defined in `lib.rs`) and downstream strict entry points.
+///
+/// Line numbers are 1-based and count the raw input lines
+/// before any `%%`-style comment stripping. Column numbers are
+/// 1-based UTF-8 character offsets within the reported line
+/// (not byte offsets).
+///
+/// This enum is `#[non_exhaustive]` so new variants can be added
+/// without breaking semver. Matchers should include a wildcard
+/// arm or upgrade with each release.
+///
+/// [`parse_mermaid_strict`]: crate::parse_mermaid_strict
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum ParseError {
+    /// A sequence, flowchart, or class/state diagram referenced
+    /// a participant or node id that was never declared, at a
+    /// site where auto-creation is not applied.
+    #[error("unknown participant '{name}' at line {line}")]
+    UnknownParticipant {
+        /// The undeclared name as it appeared in the source.
+        name: String,
+        /// 1-based line number of the reference.
+        line: u32,
+        /// Declared names that are similar to `name`; may be
+        /// empty. Useful for "did you mean?" suggestions.
+        candidates: Vec<String>,
+    },
+
+    /// A `subgraph`, `group`, `alt`, `opt`, `loop`, or other
+    /// block-style construct was opened but never closed with
+    /// its matching `end` before EOF.
+    #[error("unclosed subgraph opened at line {opened_at}")]
+    UnclosedSubgraph {
+        /// 1-based line number of the opening `subgraph` (or
+        /// equivalent) keyword.
+        opened_at: u32,
+    },
+
+    /// A token appeared where a different token was expected
+    /// (e.g. a line started with an arrow operator and no
+    /// source node, or a quoted string was not closed).
+    #[error("unexpected token '{found}' at {line}:{col}; expected {expected}")]
+    UnexpectedToken {
+        /// 1-based line number.
+        line: u32,
+        /// 1-based character-column number.
+        col: u32,
+        /// The token or fragment that was actually encountered.
+        found: String,
+        /// A short human-readable description of what would
+        /// have been valid here (e.g. `"node identifier"`,
+        /// `"matching subgraph"`).
+        expected: String,
+    },
+
+    /// A directive such as `%%{init: ... }%%` was present but
+    /// could not be parsed. Typical causes: invalid JSON inside
+    /// the `init` block, unsupported directive name, or a
+    /// malformed opening/closing fence.
+    #[error("invalid directive '{directive}' at {line}:{col}: {reason}")]
+    InvalidDirective {
+        /// 1-based line number of the directive opening.
+        line: u32,
+        /// 1-based character-column number of the directive
+        /// opening.
+        col: u32,
+        /// The directive name (e.g. `"init"`), or `"unknown"`
+        /// if the name itself could not be extracted.
+        directive: String,
+        /// Short human-readable reason explaining what failed
+        /// (e.g. `"JSON parse error: expected comma at 1:42"`).
+        reason: String,
+    },
+}
+
+/// Bridge [`ParseError`] into [`anyhow::Error`] so the legacy
+/// [`render`]/[`render_with_options`] façade can keep its
+/// `anyhow::Result<_>` signature.
+///
+/// The derived [`std::error::Error`] from `thiserror` is enough
+/// on its own (via `anyhow`'s blanket `From<E: Error>`), so this
+/// impl exists solely to pin the semantic contract in one place
+/// and to make intent explicit at call sites such as
+/// `parse_mermaid(input).map_err(Into::into)`.
+///
+/// [`render`]: crate::render
+/// [`render_with_options`]: crate::render_with_options
+#[cfg(test)]
+mod anyhow_bridge_is_derived {
+    use super::ParseError;
+    // Compile-time check: ParseError implements std::error::Error
+    // via thiserror, which is all anyhow needs for auto-conversion.
+    const _: fn() = || {
+        fn assert_error<E: std::error::Error + Send + Sync + 'static>() {}
+        assert_error::<ParseError>();
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_error_implements_display() {
+        let e = ParseError::UnclosedSubgraph { opened_at: 7 };
+        assert_eq!(format!("{e}"), "unclosed subgraph opened at line 7");
+    }
+
+    #[test]
+    fn parse_error_unexpected_token_shape() {
+        let e = ParseError::UnexpectedToken {
+            line: 3,
+            col: 5,
+            found: "-->".into(),
+            expected: "node identifier".into(),
+        };
+        assert_eq!(
+            format!("{e}"),
+            "unexpected token '-->' at 3:5; expected node identifier"
+        );
+    }
+
+    #[test]
+    fn parse_error_invalid_directive_shape() {
+        let e = ParseError::InvalidDirective {
+            line: 1,
+            col: 1,
+            directive: "init".into(),
+            reason: "JSON parse error: expected '}'".into(),
+        };
+        assert_eq!(
+            format!("{e}"),
+            "invalid directive 'init' at 1:1: JSON parse error: expected '}'"
+        );
+    }
+
+    #[test]
+    fn parse_error_is_anyhow_convertible() {
+        let e: anyhow::Error = ParseError::UnclosedSubgraph { opened_at: 2 }.into();
+        assert!(e.to_string().contains("unclosed subgraph"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,6 +91,7 @@
 #[cfg(feature = "cli")]
 pub mod cli;
 pub mod config;
+pub mod error;
 pub mod ir;
 pub mod layout;
 pub mod layout_dump;
@@ -98,9 +99,11 @@ pub mod parser;
 pub mod render;
 mod text_metrics;
 pub mod theme;
+mod validator;
 
 // Re-export commonly used types at crate root for ergonomic library usage
 pub use config::{Config, LayoutConfig, RenderConfig};
+pub use error::ParseError;
 pub use ir::{
     DiagramKind, Direction, Edge, EdgeArrowhead, EdgeDecoration, EdgeStyle, Graph, Node, NodeLink,
     NodeShape, SequenceActivation, SequenceActivationKind, SequenceBox, StateNote,
@@ -215,10 +218,50 @@ pub fn render(input: &str) -> anyhow::Result<String> {
 /// let svg = render_with_options("flowchart LR; A-->B", opts).unwrap();
 /// ```
 pub fn render_with_options(input: &str, options: RenderOptions) -> anyhow::Result<String> {
-    let parsed = parse_mermaid(input)?;
+    render_strict(input, options).map_err(Into::into)
+}
+
+/// Parse a Mermaid diagram, surfacing typed [`ParseError`]
+/// instead of [`anyhow::Error`].
+///
+/// Runs the preflight validator (see `validator` module) before
+/// delegating to [`parse_mermaid`]. Today `parse_mermaid` has no
+/// `Err` paths of its own; the validator is the sole source of
+/// structured errors until full per-diagram-type detection lands.
+///
+/// # Errors
+///
+/// Returns a [`ParseError`] variant for any of the five starter
+/// detection paths implemented by the preflight validator:
+/// invalid `%%{init}%%` directive, unclosed subgraph, stray
+/// `end`, leading-arrow lines, or unbalanced quotes in a `click`
+/// directive.
+pub fn parse_mermaid_strict(input: &str) -> Result<ParseOutput, ParseError> {
+    validator::validate(input)?;
+    // `parse_mermaid` is total as of fork rev 84e95ab: every per-type
+    // parser terminates in an unconditional `Ok(ParseOutput { ... })`.
+    // The `expect` here is a forward-compatibility guard: if future
+    // work introduces real `Err` paths in the per-type parsers, this
+    // panic will flag the missing `ParseError` conversion before the
+    // ambiguity reaches callers.
+    Ok(parse_mermaid(input).expect("parse_mermaid has no Err paths as of fork rev 84e95ab"))
+}
+
+/// Render a Mermaid diagram to SVG, surfacing typed [`ParseError`]
+/// instead of [`anyhow::Error`].
+///
+/// Thin wrapper around [`parse_mermaid_strict`] that layouts and
+/// emits SVG on success.
+///
+/// # Errors
+///
+/// Returns a [`ParseError`] when preflight validation rejects
+/// the input; see [`parse_mermaid_strict`] for the full set of
+/// detection paths.
+pub fn render_strict(input: &str, options: RenderOptions) -> Result<String, ParseError> {
+    let parsed = parse_mermaid_strict(input)?;
     let layout = compute_layout(&parsed.graph, &options.theme, &options.layout);
-    let svg = render_svg(&layout, &options.theme, &options.layout);
-    Ok(svg)
+    Ok(render_svg(&layout, &options.theme, &options.layout))
 }
 
 /// Result of rendering with timing information.

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -5517,7 +5517,10 @@ fn parse_class_line(line: &str, graph: &mut Graph) {
     if parts.len() < 3 {
         return;
     }
-    let class_name = parts.last().unwrap().to_string();
+    let class_name = parts
+        .last()
+        .expect("parts.len() >= 3 checked above")
+        .to_string();
     let class_names: Vec<String> = class_name
         .split(',')
         .map(|name| name.trim().to_string())

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -1,0 +1,600 @@
+//! Preflight validator for mermaid source.
+//!
+//! Runs as a single-pass scan over the input lines before the
+//! kind-specific parser takes over. Detects the highest-frequency
+//! malformed-input shapes and reports them as typed [`ParseError`]
+//! variants.
+//!
+//! Coverage is deliberately narrow (see f160b acceptance criteria
+//! in `docs/error_tracking.md`): five starter detection paths on
+//! the common authoring mistakes. The full per-diagram-type
+//! validation surface is follow-up work.
+//!
+//! The validator is additive: a successful `validate` does not
+//! guarantee a successful parse, it only rules out the five
+//! specific failure modes below. Existing successful inputs parse
+//! byte-identically after validation.
+
+use crate::error::ParseError;
+
+/// Run the preflight validation pass over `input` and return
+/// `Ok(())` when none of the detected failure modes apply.
+///
+/// The five detection paths implemented here are:
+///
+/// 1. `%%{init: ... }%%` with unparseable JSON → [`ParseError::InvalidDirective`]
+/// 2. Flowchart `subgraph` without a matching `end` → [`ParseError::UnclosedSubgraph`]
+/// 3. Flowchart `end` with no open `subgraph` → [`ParseError::UnexpectedToken`]
+/// 4. Any line beginning with an arrow operator → [`ParseError::UnexpectedToken`]
+/// 5. `click NodeId "url"` with unbalanced quotes → [`ParseError::UnexpectedToken`]
+///
+/// Returns the first error encountered; does not attempt to
+/// collect multiple.
+///
+/// # Errors
+///
+/// Returns [`ParseError`] on the first detected failure mode.
+pub fn validate(input: &str) -> Result<(), ParseError> {
+    let lines: Vec<&str> = input.lines().collect();
+
+    // 1. %%{init: ...}%% directive JSON well-formedness.
+    check_init_directive(&lines)?;
+
+    // 2-3. Subgraph / end balance.
+    check_subgraph_balance(&lines)?;
+
+    // 4. Lines beginning with an arrow.
+    check_leading_arrow(&lines)?;
+
+    // 5. click directives with unbalanced quotes.
+    check_click_quotes(&lines)?;
+
+    // 6. Sequence-diagram arrows that reference a participant
+    //    name never declared (only when the diagram declares at
+    //    least one participant explicitly — otherwise mermaid's
+    //    auto-creation semantics apply and no error is raised).
+    check_sequence_participants(&lines)?;
+
+    Ok(())
+}
+
+/// Path 1: validate `%%{init: {...}}%%` directive JSON.
+///
+/// The original parser silently drops directives that fail the
+/// regex match; this check explicitly rejects a directive whose
+/// opening `%%{` fence is present but whose JSON payload does
+/// not parse, so authors get a diagnostic rather than a
+/// mysteriously-ignored directive.
+fn check_init_directive(lines: &[&str]) -> Result<(), ParseError> {
+    for (idx, raw) in lines.iter().enumerate() {
+        let line_no = u32_from_index(idx);
+        let trimmed = raw.trim_start();
+        // Character-column of the first non-whitespace, 1-based.
+        let col = col_of_first_nonws(raw);
+
+        let Some(rest) = trimmed.strip_prefix("%%{") else {
+            continue;
+        };
+        // Must end with }%%; anything else is ill-formed.
+        let Some(inside) = rest.trim_end().strip_suffix("}%%") else {
+            return Err(ParseError::InvalidDirective {
+                line: line_no,
+                col,
+                directive: "unknown".to_string(),
+                reason: "missing closing '}%%' fence".to_string(),
+            });
+        };
+        // Split directive name (e.g. "init") from its JSON body.
+        let Some(colon) = inside.find(':') else {
+            return Err(ParseError::InvalidDirective {
+                line: line_no,
+                col,
+                directive: "unknown".to_string(),
+                reason: "missing ':' between directive name and body".to_string(),
+            });
+        };
+        let name = inside[..colon].trim();
+        let body = inside[colon + 1..].trim();
+        if name != "init" {
+            // Unknown directive names are tolerated (parser may
+            // ignore them silently). Only `init` is validated.
+            continue;
+        }
+        if body.is_empty() {
+            return Err(ParseError::InvalidDirective {
+                line: line_no,
+                col,
+                directive: name.to_string(),
+                reason: "empty body".to_string(),
+            });
+        }
+        // Body should parse as JSON (mmdr's regex uses json5,
+        // so we prefer json5 here too for consistency).
+        if let Err(e) = json5::from_str::<serde_json::Value>(body) {
+            return Err(ParseError::InvalidDirective {
+                line: line_no,
+                col,
+                directive: name.to_string(),
+                reason: format!("JSON parse error: {e}"),
+            });
+        }
+    }
+    Ok(())
+}
+
+/// Paths 2-3: subgraph / end balance.
+///
+/// Tracks a stack of `subgraph` opening-line numbers. An `end`
+/// with an empty stack yields [`ParseError::UnexpectedToken`];
+/// a non-empty stack at EOF yields [`ParseError::UnclosedSubgraph`]
+/// with the line of the outermost unclosed opening.
+fn check_subgraph_balance(lines: &[&str]) -> Result<(), ParseError> {
+    let mut open_stack: Vec<u32> = Vec::new();
+    for (idx, raw) in lines.iter().enumerate() {
+        let line_no = u32_from_index(idx);
+        let trimmed = raw.trim();
+        if trimmed.is_empty() || trimmed.starts_with("%%") {
+            continue;
+        }
+        if is_subgraph_open(trimmed) {
+            open_stack.push(line_no);
+        } else if is_subgraph_close(trimmed) && open_stack.pop().is_none() {
+            let col = col_of_first_nonws(raw);
+            return Err(ParseError::UnexpectedToken {
+                line: line_no,
+                col,
+                found: "end".to_string(),
+                expected: "matching subgraph".to_string(),
+            });
+        }
+    }
+    if let Some(opened_at) = open_stack.first() {
+        return Err(ParseError::UnclosedSubgraph {
+            opened_at: *opened_at,
+        });
+    }
+    Ok(())
+}
+
+/// Path 4: lines that begin with an arrow operator.
+///
+/// `--> X`, `---> X`, `==> X`, etc., with no source node before
+/// the arrow, are illegal in every mmdr-supported diagram kind.
+/// This catches accidental pastes or omitted source identifiers.
+fn check_leading_arrow(lines: &[&str]) -> Result<(), ParseError> {
+    for (idx, raw) in lines.iter().enumerate() {
+        let line_no = u32_from_index(idx);
+        let trimmed = raw.trim_start();
+        if trimmed.is_empty() || trimmed.starts_with("%%") {
+            continue;
+        }
+        if starts_with_arrow(trimmed) {
+            let col = col_of_first_nonws(raw);
+            let found_token: String = trimmed.chars().take_while(|c| !c.is_whitespace()).collect();
+            return Err(ParseError::UnexpectedToken {
+                line: line_no,
+                col,
+                found: found_token,
+                expected: "node identifier".to_string(),
+            });
+        }
+    }
+    Ok(())
+}
+
+/// Path 5: `click NodeId "url" ["tooltip"]` with unbalanced
+/// double quotes.
+fn check_click_quotes(lines: &[&str]) -> Result<(), ParseError> {
+    for (idx, raw) in lines.iter().enumerate() {
+        let line_no = u32_from_index(idx);
+        let trimmed = raw.trim_start();
+        if !trimmed.starts_with("click ") && !trimmed.starts_with("click\t") {
+            continue;
+        }
+        let quote_count = trimmed.chars().filter(|c| *c == '"').count();
+        if quote_count % 2 == 1 {
+            // Column of the first unmatched quote is a
+            // reasonable anchor.
+            let leading_ws = raw.len() - trimmed.len();
+            let quote_byte = trimmed.find('"').unwrap_or(0);
+            let col = col_of_char_offset(raw, leading_ws + quote_byte)
+                .unwrap_or_else(|| col_of_first_nonws(raw));
+            return Err(ParseError::UnexpectedToken {
+                line: line_no,
+                col,
+                found: "\"".to_string(),
+                expected: "matching double quote".to_string(),
+            });
+        }
+    }
+    Ok(())
+}
+
+/// Path 6: sequence-diagram arrows that reference an undeclared
+/// participant.
+///
+/// Mermaid normally auto-creates participants on first use. This
+/// check only activates when the author has explicitly declared
+/// at least one `participant` (or `actor`) in the diagram: in
+/// that case it is very likely a typo when a subsequent arrow
+/// references a name outside the declared set, and surfacing the
+/// typo as [`ParseError::UnknownParticipant`] is far more useful
+/// than silently auto-creating a second actor with the wrong
+/// name.
+fn check_sequence_participants(lines: &[&str]) -> Result<(), ParseError> {
+    if !looks_like_sequence_diagram(lines) {
+        return Ok(());
+    }
+    let declared = collect_declared_participants(lines);
+    if declared.is_empty() {
+        // No explicit declarations: auto-creation applies, no
+        // error surface.
+        return Ok(());
+    }
+    for (idx, raw) in lines.iter().enumerate() {
+        let line_no = u32_from_index(idx);
+        let trimmed = raw.trim();
+        if trimmed.is_empty() || trimmed.starts_with("%%") {
+            continue;
+        }
+        if let Some((left, right)) = split_sequence_arrow(trimmed) {
+            for name in [left.trim(), right.trim()] {
+                // Skip empty (defensive) and metadata tokens.
+                if name.is_empty() {
+                    continue;
+                }
+                if !declared.iter().any(|d| d == name) {
+                    let candidates = nearest_candidates(name, &declared);
+                    return Err(ParseError::UnknownParticipant {
+                        name: name.to_string(),
+                        line: line_no,
+                        candidates,
+                    });
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------
+
+/// Convert a 0-based line index (as produced by `enumerate()` on
+/// `input.lines()`) to the 1-based line number this module uses.
+fn u32_from_index(idx: usize) -> u32 {
+    u32::try_from(idx + 1).unwrap_or(u32::MAX)
+}
+
+/// 1-based character column of the first non-whitespace
+/// character in `raw`, or `1` when the line is all whitespace
+/// or empty.
+fn col_of_first_nonws(raw: &str) -> u32 {
+    let col = raw
+        .char_indices()
+        .find(|(_, c)| !c.is_whitespace())
+        .map_or(0, |(i, _)| raw[..i].chars().count());
+    u32::try_from(col + 1).unwrap_or(u32::MAX)
+}
+
+/// 1-based character column of the byte-offset `byte_offset`
+/// within `raw`. Returns `None` when the offset does not fall on
+/// a character boundary.
+fn col_of_char_offset(raw: &str, byte_offset: usize) -> Option<u32> {
+    if !raw.is_char_boundary(byte_offset) {
+        return None;
+    }
+    let col = raw[..byte_offset].chars().count();
+    Some(u32::try_from(col + 1).unwrap_or(u32::MAX))
+}
+
+/// True if the trimmed line opens a subgraph block
+/// (case-insensitive `subgraph` keyword at line start).
+fn is_subgraph_open(trimmed: &str) -> bool {
+    let lower = trimmed.to_ascii_lowercase();
+    lower == "subgraph" || lower.starts_with("subgraph ") || lower.starts_with("subgraph\t")
+}
+
+/// True if the trimmed line is exactly the `end` keyword
+/// (closing a subgraph / alt / opt / loop block).
+fn is_subgraph_close(trimmed: &str) -> bool {
+    let lower = trimmed.to_ascii_lowercase();
+    // The `end` keyword can be followed by a comment (`end %% close`).
+    lower == "end"
+        || lower.starts_with("end ")
+        || lower.starts_with("end\t")
+        || lower.starts_with("end%%")
+}
+
+/// True if `trimmed` begins with any arrow operator mmdr
+/// recognises. Matches the pattern used by the library's own
+/// `FLOW_EDGE_PATTERN` at a line start.
+fn starts_with_arrow(trimmed: &str) -> bool {
+    let bytes = trimmed.as_bytes();
+    if bytes.is_empty() {
+        return false;
+    }
+    match bytes[0] {
+        b'-' | b'=' | b'~' | b'.' | b'<' => {
+            // Consume leading dashes / equals / tildes / dots,
+            // and require something resembling an arrow head
+            // within the run.
+            bytes
+                .iter()
+                .copied()
+                .take_while(|&b| matches!(b, b'-' | b'=' | b'~' | b'.' | b'<' | b'>' | b'o' | b'x'))
+                .any(|b| matches!(b, b'>' | b'<' | b'-' | b'='))
+                && bytes
+                    .iter()
+                    .copied()
+                    .take(16)
+                    .any(|b| matches!(b, b'>' | b'<'))
+        }
+        _ => false,
+    }
+}
+
+/// True when the input's first non-empty, non-comment line
+/// begins with `sequenceDiagram` (case-insensitive).
+fn looks_like_sequence_diagram(lines: &[&str]) -> bool {
+    for raw in lines {
+        let t = raw.trim();
+        if t.is_empty() || t.starts_with("%%") {
+            continue;
+        }
+        return t.to_ascii_lowercase().starts_with("sequencediagram");
+    }
+    false
+}
+
+/// Extract the set of names declared via `participant NAME`,
+/// `participant NAME as ALIAS`, or `actor NAME ...`.
+///
+/// Both the raw name and the alias (if present) are added, so an
+/// arrow can refer to either form.
+fn collect_declared_participants(lines: &[&str]) -> Vec<String> {
+    let mut declared: Vec<String> = Vec::new();
+    for raw in lines {
+        let t = raw.trim();
+        let (keyword, rest) = if let Some(r) = t.strip_prefix("participant ") {
+            ("participant", r)
+        } else if let Some(r) = t.strip_prefix("actor ") {
+            ("actor", r)
+        } else {
+            continue;
+        };
+        let _ = keyword;
+        // Supported shapes: "NAME", "NAME as ALIAS".
+        let rest = rest.trim();
+        if let Some((name, alias_part)) = rest.split_once(" as ") {
+            let name = name.trim().to_string();
+            let alias = alias_part.trim().to_string();
+            if !name.is_empty() {
+                declared.push(name);
+            }
+            if !alias.is_empty() {
+                declared.push(alias);
+            }
+        } else if !rest.is_empty() {
+            declared.push(rest.to_string());
+        }
+    }
+    declared
+}
+
+/// If `trimmed` is a sequence-diagram arrow line, return the
+/// source and target names. Otherwise `None`.
+///
+/// Matches the common arrow shapes: `->`, `-->`, `->>`, `-x`,
+/// `--x`, `-)`, `--)`. Message text after a `:` is stripped.
+fn split_sequence_arrow(trimmed: &str) -> Option<(&str, &str)> {
+    // Strip any trailing `: message` payload.
+    let before_colon = trimmed.split_once(':').map_or(trimmed, |(a, _)| a);
+    // Longer patterns first so `-->` wins over `->`.
+    const PATTERNS: &[&str] = &["-->>", "--x", "--)", "-->", "->>", "->", "-x", "-)"];
+    for pat in PATTERNS {
+        if let Some((lhs, rhs)) = before_colon.split_once(pat) {
+            return Some((lhs, rhs));
+        }
+    }
+    None
+}
+
+/// Return up to three declared names whose lowercase form shares
+/// a prefix with `target` or differs only by case, as
+/// "did-you-mean" suggestions. Deterministic order (source
+/// order).
+fn nearest_candidates(target: &str, declared: &[String]) -> Vec<String> {
+    let target_lower = target.to_ascii_lowercase();
+    declared
+        .iter()
+        .filter(|d| {
+            let dl = d.to_ascii_lowercase();
+            dl == target_lower || dl.starts_with(&target_lower) || target_lower.starts_with(&dl)
+        })
+        .take(3)
+        .cloned()
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- Path 1: init directive ---------------------------------------
+
+    #[test]
+    fn init_directive_valid_json_passes() {
+        let input = r#"%%{init: {"theme": "dark"}}%%
+flowchart LR
+A-->B"#;
+        assert!(validate(input).is_ok());
+    }
+
+    #[test]
+    fn init_directive_invalid_json_is_reported() {
+        let input = r#"%%{init: {theme dark}}%%
+flowchart LR"#;
+        let err = validate(input).unwrap_err();
+        assert!(
+            matches!(err, ParseError::InvalidDirective { directive, .. } if directive == "init")
+        );
+    }
+
+    #[test]
+    fn init_directive_missing_colon_is_reported() {
+        let input = r#"%%{init}%%
+flowchart LR"#;
+        let err = validate(input).unwrap_err();
+        assert!(matches!(err, ParseError::InvalidDirective { .. }));
+    }
+
+    #[test]
+    fn init_directive_unknown_name_is_tolerated() {
+        // Only `init` is validated; unknown directive names pass
+        // through (original parser semantics).
+        let input = r#"%%{customdirective: {"x": 1}}%%
+flowchart LR"#;
+        assert!(validate(input).is_ok());
+    }
+
+    // --- Paths 2-3: subgraph balance ---------------------------------
+
+    #[test]
+    fn subgraph_unclosed_is_reported() {
+        let input = "flowchart LR\nsubgraph S\n  A --> B\n";
+        let err = validate(input).unwrap_err();
+        assert!(
+            matches!(err, ParseError::UnclosedSubgraph { opened_at: 2 }),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn subgraph_balanced_passes() {
+        let input = "flowchart LR\nsubgraph S\n  A --> B\nend\n";
+        assert!(validate(input).is_ok());
+    }
+
+    #[test]
+    fn nested_subgraphs_balanced_pass() {
+        let input = "flowchart LR\nsubgraph O\n  subgraph I\n    A --> B\n  end\nend\n";
+        assert!(validate(input).is_ok());
+    }
+
+    #[test]
+    fn nested_subgraphs_inner_unclosed_is_reported() {
+        let input = "flowchart LR\nsubgraph O\n  subgraph I\n    A --> B\nend\n";
+        let err = validate(input).unwrap_err();
+        assert!(matches!(err, ParseError::UnclosedSubgraph { .. }));
+    }
+
+    #[test]
+    fn stray_end_without_open_is_reported() {
+        let input = "flowchart LR\nA --> B\nend\n";
+        let err = validate(input).unwrap_err();
+        assert!(matches!(
+            err,
+            ParseError::UnexpectedToken { found, expected, .. }
+                if found == "end" && expected == "matching subgraph"
+        ));
+    }
+
+    // --- Path 4: leading arrow ----------------------------------------
+
+    #[test]
+    fn leading_arrow_is_reported() {
+        let input = "flowchart LR\n--> B\n";
+        let err = validate(input).unwrap_err();
+        assert!(matches!(
+            err,
+            ParseError::UnexpectedToken { expected, .. }
+                if expected == "node identifier"
+        ));
+    }
+
+    #[test]
+    fn leading_thick_arrow_is_reported() {
+        let input = "flowchart LR\n==> B\n";
+        let err = validate(input).unwrap_err();
+        assert!(matches!(err, ParseError::UnexpectedToken { .. }));
+    }
+
+    #[test]
+    fn regular_edge_passes() {
+        let input = "flowchart LR\nA --> B\n";
+        assert!(validate(input).is_ok());
+    }
+
+    // --- Path 5: click directive quoting ------------------------------
+
+    #[test]
+    fn click_unbalanced_quote_is_reported() {
+        let input = "flowchart LR\nA --> B\nclick A \"https://example.com\n";
+        let err = validate(input).unwrap_err();
+        assert!(matches!(
+            err,
+            ParseError::UnexpectedToken { expected, .. }
+                if expected == "matching double quote"
+        ));
+    }
+
+    #[test]
+    fn click_balanced_passes() {
+        let input = "flowchart LR\nA --> B\nclick A \"https://example.com\"\n";
+        assert!(validate(input).is_ok());
+    }
+
+    // --- Path 6: sequence unknown participant -------------------------
+
+    #[test]
+    fn sequence_without_declarations_passes() {
+        // Auto-creation applies -- no error.
+        let input = "sequenceDiagram\nAlice->>Bob: hi\n";
+        assert!(validate(input).is_ok());
+    }
+
+    #[test]
+    fn sequence_declared_participants_match_passes() {
+        let input = "sequenceDiagram\nparticipant Alice\nparticipant Bob\nAlice->>Bob: hi\n";
+        assert!(validate(input).is_ok());
+    }
+
+    #[test]
+    fn sequence_unknown_participant_on_right_is_reported() {
+        let input = "sequenceDiagram\nparticipant Alice\nparticipant Bob\nAlice->>Carol: hi\n";
+        let err = validate(input).unwrap_err();
+        assert!(
+            matches!(err, ParseError::UnknownParticipant { ref name, line: 4, .. }
+                if name == "Carol"),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn sequence_unknown_participant_on_left_is_reported() {
+        let input = "sequenceDiagram\nparticipant Alice\nparticipant Bob\nCarol->>Bob: hi\n";
+        let err = validate(input).unwrap_err();
+        assert!(matches!(err, ParseError::UnknownParticipant { .. }));
+    }
+
+    #[test]
+    fn sequence_participant_as_alias_is_honored() {
+        // Either the raw name OR the alias satisfies the reference.
+        let input = "sequenceDiagram\nparticipant A as Alice\nA->>A: hi\n";
+        assert!(validate(input).is_ok());
+    }
+
+    // --- Edge cases ---------------------------------------------------
+
+    #[test]
+    fn empty_input_passes() {
+        assert!(validate("").is_ok());
+    }
+
+    #[test]
+    fn comment_only_input_passes() {
+        assert!(validate("%% just a comment\n%% and another\n").is_ok());
+    }
+}

--- a/tests/parse_errors.rs
+++ b/tests/parse_errors.rs
@@ -1,0 +1,283 @@
+//! Integration tests for the strict parse API and `ParseError`.
+//!
+//! These tests exercise the public `parse_mermaid_strict` and
+//! `render_strict` entry points against deliberately-malformed
+//! inputs, and assert each produces the correct `ParseError`
+//! variant via `matches!`.
+//!
+//! Coverage: at least 5 cases per `ParseError` variant, 24 total.
+
+use mermaid_rs_renderer::{ParseError, RenderOptions, parse_mermaid_strict, render_strict};
+
+// =====================================================================
+// InvalidDirective (5 cases)
+// =====================================================================
+
+#[test]
+fn invalid_directive_malformed_json() {
+    let input = r#"%%{init: {theme dark}}%%
+flowchart LR"#;
+    let err = parse_mermaid_strict(input).unwrap_err();
+    assert!(matches!(
+        err,
+        ParseError::InvalidDirective { ref directive, .. }
+            if directive == "init"
+    ));
+}
+
+#[test]
+fn invalid_directive_missing_colon() {
+    let input = "%%{init}%%\nflowchart LR\n";
+    let err = parse_mermaid_strict(input).unwrap_err();
+    assert!(matches!(err, ParseError::InvalidDirective { .. }));
+}
+
+#[test]
+fn invalid_directive_missing_closing_fence() {
+    let input = "%%{init: {\"theme\": \"dark\"}\nflowchart LR\n";
+    let err = parse_mermaid_strict(input).unwrap_err();
+    assert!(matches!(err, ParseError::InvalidDirective { .. }));
+}
+
+#[test]
+fn invalid_directive_empty_init_body() {
+    let input = "%%{init: }%%\nflowchart LR\n";
+    let err = parse_mermaid_strict(input).unwrap_err();
+    assert!(matches!(err, ParseError::InvalidDirective { .. }));
+}
+
+#[test]
+fn invalid_directive_unparseable_nested_json() {
+    let input = r#"%%{init: {"theme": "dark", "themeVariables": {primaryColor}}}%%
+flowchart LR"#;
+    let err = parse_mermaid_strict(input).unwrap_err();
+    assert!(matches!(err, ParseError::InvalidDirective { .. }));
+}
+
+// =====================================================================
+// UnclosedSubgraph (5 cases)
+// =====================================================================
+
+#[test]
+fn unclosed_subgraph_simple() {
+    let input = "flowchart LR\nsubgraph S\n  A --> B\n";
+    let err = parse_mermaid_strict(input).unwrap_err();
+    assert!(matches!(err, ParseError::UnclosedSubgraph { opened_at: 2 }));
+}
+
+#[test]
+fn unclosed_subgraph_nested_inner() {
+    let input = "flowchart LR\nsubgraph Outer\n  subgraph Inner\n    A --> B\nend\n";
+    let err = parse_mermaid_strict(input).unwrap_err();
+    assert!(matches!(err, ParseError::UnclosedSubgraph { .. }));
+}
+
+#[test]
+fn unclosed_subgraph_multiple_opens() {
+    let input = "flowchart LR\nsubgraph A\nsubgraph B\n";
+    let err = parse_mermaid_strict(input).unwrap_err();
+    // Outermost open is reported.
+    assert!(matches!(err, ParseError::UnclosedSubgraph { opened_at: 2 }));
+}
+
+#[test]
+fn unclosed_subgraph_with_nodes_but_no_end() {
+    let input = "flowchart TD\nsubgraph DataFlow\n  Input --> Process\n  Process --> Output\n";
+    let err = parse_mermaid_strict(input).unwrap_err();
+    assert!(matches!(err, ParseError::UnclosedSubgraph { .. }));
+}
+
+#[test]
+fn unclosed_subgraph_with_title() {
+    let input = "flowchart LR\nsubgraph \"My Title\"\n  A --> B\n";
+    let err = parse_mermaid_strict(input).unwrap_err();
+    assert!(matches!(err, ParseError::UnclosedSubgraph { .. }));
+}
+
+// =====================================================================
+// UnexpectedToken (7 cases -- three sub-shapes covered)
+// =====================================================================
+
+#[test]
+fn unexpected_token_stray_end_without_open() {
+    let input = "flowchart LR\nA --> B\nend\n";
+    let err = parse_mermaid_strict(input).unwrap_err();
+    assert!(matches!(
+        err,
+        ParseError::UnexpectedToken { ref found, ref expected, .. }
+            if found == "end" && expected == "matching subgraph"
+    ));
+}
+
+#[test]
+fn unexpected_token_leading_arrow() {
+    let input = "flowchart LR\n--> B\n";
+    let err = parse_mermaid_strict(input).unwrap_err();
+    assert!(matches!(
+        err,
+        ParseError::UnexpectedToken { ref expected, .. }
+            if expected == "node identifier"
+    ));
+}
+
+#[test]
+fn unexpected_token_leading_thick_arrow() {
+    let input = "flowchart LR\n==> X\n";
+    let err = parse_mermaid_strict(input).unwrap_err();
+    assert!(matches!(
+        err,
+        ParseError::UnexpectedToken { ref expected, .. }
+            if expected == "node identifier"
+    ));
+}
+
+#[test]
+fn unexpected_token_leading_dotted_arrow() {
+    let input = "flowchart LR\n-.-> Y\n";
+    let err = parse_mermaid_strict(input).unwrap_err();
+    assert!(matches!(err, ParseError::UnexpectedToken { .. }));
+}
+
+#[test]
+fn unexpected_token_click_unbalanced_quote() {
+    let input = "flowchart LR\nA --> B\nclick A \"https://example.com\n";
+    let err = parse_mermaid_strict(input).unwrap_err();
+    assert!(matches!(
+        err,
+        ParseError::UnexpectedToken { ref expected, .. }
+            if expected == "matching double quote"
+    ));
+}
+
+#[test]
+fn unexpected_token_click_three_quotes() {
+    let input = "flowchart LR\nA --> B\nclick A \"https://a\" \"tooltip\n";
+    let err = parse_mermaid_strict(input).unwrap_err();
+    assert!(matches!(err, ParseError::UnexpectedToken { .. }));
+}
+
+#[test]
+fn unexpected_token_stray_end_in_sequence() {
+    let input = "sequenceDiagram\nAlice->>Bob: hi\nend\n";
+    let err = parse_mermaid_strict(input).unwrap_err();
+    assert!(matches!(
+        err,
+        ParseError::UnexpectedToken { ref found, .. }
+            if found == "end"
+    ));
+}
+
+// =====================================================================
+// UnknownParticipant (5 cases)
+// =====================================================================
+
+#[test]
+fn unknown_participant_on_rhs() {
+    let input = "sequenceDiagram
+participant Alice
+participant Bob
+Alice->>Carol: hi
+";
+    let err = parse_mermaid_strict(input).unwrap_err();
+    assert!(matches!(
+        err,
+        ParseError::UnknownParticipant { ref name, .. }
+            if name == "Carol"
+    ));
+}
+
+#[test]
+fn unknown_participant_on_lhs() {
+    let input = "sequenceDiagram
+participant Alice
+participant Bob
+Carol->>Bob: hi
+";
+    let err = parse_mermaid_strict(input).unwrap_err();
+    assert!(matches!(
+        err,
+        ParseError::UnknownParticipant { ref name, .. }
+            if name == "Carol"
+    ));
+}
+
+#[test]
+fn unknown_participant_reports_line_number() {
+    let input = "sequenceDiagram
+participant A
+participant B
+A->>B: ok
+A->>C: bad
+";
+    let err = parse_mermaid_strict(input).unwrap_err();
+    assert!(matches!(
+        err,
+        ParseError::UnknownParticipant { line: 5, .. }
+    ));
+}
+
+#[test]
+fn unknown_participant_with_similar_candidate() {
+    let input = "sequenceDiagram
+participant Alice
+participant Alicia
+Alice->>Alicee: typo
+";
+    let err = parse_mermaid_strict(input).unwrap_err();
+    match err {
+        ParseError::UnknownParticipant {
+            name, candidates, ..
+        } => {
+            assert_eq!(name, "Alicee");
+            assert!(
+                candidates.iter().any(|c| c == "Alice" || c == "Alicia"),
+                "candidates = {candidates:?}"
+            );
+        }
+        other => panic!("expected UnknownParticipant, got {other:?}"),
+    }
+}
+
+#[test]
+fn unknown_participant_with_actor_declaration() {
+    let input = "sequenceDiagram
+actor Alice
+actor Bob
+Alice->>Charlie: hi
+";
+    let err = parse_mermaid_strict(input).unwrap_err();
+    assert!(matches!(
+        err,
+        ParseError::UnknownParticipant { ref name, .. }
+            if name == "Charlie"
+    ));
+}
+
+// =====================================================================
+// Happy path (sanity check that valid input still parses / renders)
+// =====================================================================
+
+#[test]
+fn valid_flowchart_parses_strict() {
+    let out = parse_mermaid_strict("flowchart LR\nA --> B\n");
+    assert!(out.is_ok(), "got {:?}", out.err());
+}
+
+#[test]
+fn valid_flowchart_renders_strict() {
+    let svg = render_strict("flowchart LR\nA --> B\n", RenderOptions::default())
+        .expect("valid flowchart should render");
+    assert!(svg.contains("<svg"));
+    assert!(svg.contains("</svg>"));
+}
+
+#[test]
+fn valid_sequence_with_declarations_renders_strict() {
+    let input = "sequenceDiagram
+participant Alice
+participant Bob
+Alice->>Bob: hi
+";
+    let svg = render_strict(input, RenderOptions::default()).expect("valid sequence should render");
+    assert!(svg.contains("<svg"));
+}


### PR DESCRIPTION
## Summary

Adds a typed `ParseError` enum alongside the existing `anyhow::Error` API, plus strict library entry points `parse_mermaid_strict` and `render_strict`. The existing `render`, `render_with_options`, and `parse_mermaid` signatures are unchanged; they delegate to the strict variants and map `ParseError` through `Into<anyhow::Error>`.

The motivation is error classification for consumers (CMSs, editors, LLM correction loops) that currently have to scrape `anyhow::Error` strings to diagnose malformed input. Today's `parse_mermaid` signature is `Result<ParseOutput>` but every per-type parser ends with an unconditional `Ok(...)`, so malformed input silently produces a partial graph. This PR keeps that behaviour as the default while adding an opt-in strict path that reports structured errors.

## API surface

```rust
#[derive(Debug, thiserror::Error)]
#[non_exhaustive]
pub enum ParseError {
    UnknownParticipant { name, line, candidates },
    UnclosedSubgraph { opened_at },
    UnexpectedToken { line, col, found, expected },
    InvalidDirective { line, col, directive, reason },
}

pub fn parse_mermaid_strict(input: &str) -> Result<ParseOutput, ParseError>;
pub fn render_strict(input: &str, options: RenderOptions) -> Result<String, ParseError>;
```

All four variants carry 1-based line / 1-based character-column fields where applicable. The conventions are pinned in `docs/error_tracking.md` so follow-up detection paths stay consistent.

## Detection coverage (preflight validator)

A single-pass line scan runs before the per-type parsers. Six starter detection paths:

1. `%%{init: ...}%%` with unparseable JSON → `InvalidDirective` (current parser silently drops malformed directives).
2. `subgraph` block without a matching `end` → `UnclosedSubgraph { opened_at }` for the outermost open.
3. Stray `end` with no open block → `UnexpectedToken { found: "end", expected: "matching subgraph" }`.
4. Line beginning with an arrow operator (`-->`, `==>`, `-.->`) → `UnexpectedToken { expected: "node identifier" }`.
5. `click NodeId "url"` with unbalanced double quotes → `UnexpectedToken { expected: "matching double quote" }`.
6. Sequence diagrams that declare participants explicitly and then arrow-reference an undeclared name → `UnknownParticipant` with "did you mean?" candidates. **Auto-creation semantics are preserved when no participants are declared** — this check only fires when the author already committed to explicit declarations.

Full per-diagram-type detection across all 23 kinds is follow-up work; the preflight pass establishes the API and conventions.

## Unwrap audit (new `docs/unwrap_audit.md`)

A common framing of "91 parser unwraps that can panic on malformed input" did not survive inspection. Of 91 `.unwrap()` occurrences in `src/parser.rs`:

- **81 are inside `#[cfg(test)]`** and ship zero code.
- 9 of the remaining 10 are `Lazy<Regex>::new()` at module load (compile-time safe).
- The last, `parts.last().unwrap()` at `parser.rs:5405`, is guarded by `if parts.len() < 3 { return; }` two lines above; rewritten as `.expect("parts.len() >= 3 checked above")` in this PR for clarity.

`src/render.rs` has one production `.unwrap()` (`Size::from_wh(800.0, 600.0)` — const literals). `src/lib.rs` has zero (all hits are in `///` / `//!` doc comments).

**Zero production unwraps are user-input reachable.** The audit is committed to preempt future repeats of the flawed count.

## Test plan

- `cargo test --release` — 162 unit tests pass (existing 137 + 25 new validator unit tests), 1 integration harness (`layout_suite`), 25 new integration tests in `tests/parse_errors.rs` (at least 5 per `ParseError` variant), 5 doc tests. All green on Apple M-series / Linux x86_64.
- No changes to any existing test fixture SVG output. Valid inputs render byte-identically.
- `cargo clippy --all-features`: the single warning this PR introduced (a collapsible-if in `src/validator.rs`) is fixed. The 37 remaining warnings in the tree are all pre-existing and not touched by this PR.

## Commit

https://github.com/zoosky/mermaid-rs-renderer/commit/153f8dbbb52f2b345f6c9dc3e5b5edeb6fc56b2f

## Followup PRs

If this lands: incrementally add `ParseError`-emitting detection paths inside each per-type parser (flowchart syntax errors with precise column, sequence `activate`/`deactivate` balance, state fork/join, Gantt `excludes` parse errors, etc.). Each is additive and does not change the public API.