### PR TITLE
feat(mindmap): support tidy-tree and lr-tree layouts (#77)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1505,6 +1505,14 @@ fn merge_init_config(mut config: Config, init: serde_json::Value) -> Config {
             config.layout.c4.external_component_queue_border_color = val;
         }
     }
+    if let Some(mindmap) = init.get("mindmap").and_then(|v| v.as_object()) {
+        if let Some(val) = mindmap
+            .get("layoutAlgorithm")
+            .and_then(|v| v.as_str())
+        {
+            config.layout.mindmap.layout_algorithm = val.to_string();
+        }
+    }
     config.render.background = config.theme.background.clone();
     config
 }

--- a/src/layout/mindmap.rs
+++ b/src/layout/mindmap.rs
@@ -403,13 +403,16 @@ fn place_tidy_tree(
     side_map
 }
 
-/// Build the four-point control polyline that Mermaid JS feeds to its
-/// `curveBasis` line generator for tidy-tree edges. The two extra middle
-/// points share the source's and target's `y` respectively, so a B-spline
-/// through them leaves and arrives at the nodes nearly horizontally. The
-/// start/end points are then clipped to the source/target shape boundary
-/// using the adjacent middle point as the outside reference, matching
-/// Mermaid JS's second-pass intersection in `calculateEdgePositions`.
+/// Build the control polyline that Mermaid JS feeds to its `curveBasis`
+/// line generator for tidy-tree edges.
+///
+/// We deliberately match the *older* (pre-#7572) Mermaid layout where
+/// root-sourced edges only push the *target*'s middle point (`mid_b` at the
+/// target's `y`). The start anchor is then the intersection of the line
+/// `root_center → mid_b` with the root's bounding rectangle, which lets
+/// each child's edge anchor on a different side / corner of the root box
+/// instead of stacking on the horizontal midline. Non-root edges use the
+/// usual four-point routing so the curve leaves the source horizontally.
 fn tidy_tree_edge_points(
     from_layout: &NodeLayout,
     to_layout: &NodeLayout,
@@ -427,8 +430,8 @@ fn tidy_tree_edge_points(
     );
     let intersection_shift = 30.0_f32;
 
-    // Side of the *child* (target) determines the growth direction. Edges from
-    // the root inherit that direction.
+    let from_is_root = !side_map.contains_key(from_id);
+    let to_is_root = !side_map.contains_key(to_id);
     let side = side_map
         .get(to_id)
         .copied()
@@ -439,30 +442,46 @@ fn tidy_tree_edge_points(
         MindmapSide::Left => -1.0,
     };
 
-    // Mid points pushed outward by `intersection_shift` along the growth axis.
-    let mid_a = (
-        from_center.0 + direction * (from_layout.width / 2.0 + intersection_shift),
-        from_center.1,
-    );
-    let mid_b = (
-        to_center.0 - direction * (to_layout.width / 2.0 + intersection_shift),
-        to_center.1,
-    );
+    let mut points: Vec<(f32, f32)> = Vec::with_capacity(4);
+    // Placeholder for start; clipped after the middle points are known.
+    points.push(from_center);
+    if !from_is_root {
+        // mid_a — sits at the source's center y so the spline leaves the
+        // source rectangle horizontally.
+        points.push((
+            from_center.0 + direction * (from_layout.width / 2.0 + intersection_shift),
+            from_center.1,
+        ));
+    }
+    if !to_is_root {
+        // mid_b — sits at the target's center y so the spline arrives
+        // horizontally at the target rectangle.
+        points.push((
+            to_center.0 - direction * (to_layout.width / 2.0 + intersection_shift),
+            to_center.1,
+        ));
+    }
+    points.push(to_center);
 
-    // Endpoints clipped to the source/target shape boundary along the line
-    // toward the adjacent middle point. This spreads root-edge starts around
-    // the circumference instead of stacking them on the horizontal midline.
-    let start = clip_to_shape(from_layout, from_center, mid_a);
-    let end = clip_to_shape(to_layout, to_center, mid_b);
-
-    vec![start, mid_a, mid_b, end]
+    // Recompute the start anchor toward the next control point and the end
+    // anchor toward the previous control point, matching Mermaid JS's
+    // post-loop second-pass intersection in `calculateEdgePositions`.
+    let second = points[1];
+    points[0] = clip_to_rect(from_layout, from_center, second);
+    let last = points.len() - 1;
+    let second_last = points[last - 1];
+    points[last] = clip_to_rect(to_layout, to_center, second_last);
+    points
 }
 
-/// Clip a line that exits `node` toward `outside` to the node's shape
-/// boundary. Circles and the default mindmap shape use the inscribed-circle
-/// intersection (matching Mermaid JS's `computeCircleEdgeIntersection`);
-/// every other shape uses an axis-aligned-rectangle intersection.
-fn clip_to_shape(
+/// Clip a line that exits `node` toward `outside` to the node's
+/// axis-aligned bounding rectangle. Mermaid JS uses the bounding box
+/// intersection for every shape — including the circular mindmap root —
+/// because the renderer attaches a generic rectangle `intersect` method
+/// based on the rendered SVG `getBBox()`. Matching that lets the edge
+/// anchors fan around the root instead of clustering on its horizontal
+/// midline.
+fn clip_to_rect(
     node: &NodeLayout,
     center: (f32, f32),
     outside: (f32, f32),
@@ -477,28 +496,18 @@ fn clip_to_shape(
     let ny = dy / len;
     let half_w = node.width / 2.0;
     let half_h = node.height / 2.0;
-    match node.shape {
-        crate::ir::NodeShape::Circle | crate::ir::NodeShape::DoubleCircle => {
-            let radius = half_w.min(half_h);
-            (center.0 + nx * radius, center.1 + ny * radius)
-        }
-        _ => {
-            // Rectangle intersection: scale the unit vector so it just hits
-            // either the horizontal or vertical edge.
-            let tx = if nx.abs() > 1e-6 {
-                half_w / nx.abs()
-            } else {
-                f32::INFINITY
-            };
-            let ty = if ny.abs() > 1e-6 {
-                half_h / ny.abs()
-            } else {
-                f32::INFINITY
-            };
-            let t = tx.min(ty);
-            (center.0 + nx * t, center.1 + ny * t)
-        }
-    }
+    let tx = if nx.abs() > 1e-6 {
+        half_w / nx.abs()
+    } else {
+        f32::INFINITY
+    };
+    let ty = if ny.abs() > 1e-6 {
+        half_h / ny.abs()
+    } else {
+        f32::INFINITY
+    };
+    let t = tx.min(ty);
+    (center.0 + nx * t, center.1 + ny * t)
 }
 
 /// Run the tidy-tree algorithm over a forest rooted at the given children.

--- a/src/layout/mindmap.rs
+++ b/src/layout/mindmap.rs
@@ -313,6 +313,11 @@ enum MindmapSide {
     Right,
 }
 
+/// Pixel offset between the visible boundary of a circular root and the
+/// edge anchor. Pushed outward so the curveBasis spline visibly leaves the
+/// circumference instead of touching it.
+const CIRCLE_ANCHOR_GAP: f32 = 15.0;
+
 /// Lay out a mindmap using the non-layered tidy-tree algorithm. When
 /// `lr_only` is true, every branch grows to the right of the root (matching
 /// the requested `lr-tree` algorithm). Otherwise children alternate between
@@ -507,7 +512,9 @@ fn clip_to_rect(
         if len < 1e-3 {
             return center;
         }
-        let radius = (node.width.min(node.height)) / 2.0;
+        // Anchor a small distance *outside* the circle so the curveBasis
+        // edge visibly leaves the circumference instead of touching it.
+        let radius = (node.width.min(node.height)) / 2.0 + CIRCLE_ANCHOR_GAP;
         return (center.0 + dx / len * radius, center.1 + dy / len * radius);
     }
     let x = center.0;

--- a/src/layout/mindmap.rs
+++ b/src/layout/mindmap.rs
@@ -475,39 +475,91 @@ fn tidy_tree_edge_points(
 }
 
 /// Clip a line that exits `node` toward `outside` to the node's
-/// axis-aligned bounding rectangle. Mermaid JS uses the bounding box
-/// intersection for every shape — including the circular mindmap root —
-/// because the renderer attaches a generic rectangle `intersect` method
-/// based on the rendered SVG `getBBox()`. Matching that lets the edge
-/// anchors fan around the root instead of clustering on its horizontal
-/// midline.
+/// axis-aligned bounding rectangle. This is a faithful Rust port of
+/// Mermaid JS's `intersection()` in `mermaid-layout-tidy-tree/src/layout.ts`
+/// — including its quirk where the top/bottom branch returns a point that
+/// does *not* lie on the straight inside→outside line. Reproducing the
+/// quirk is necessary to get the same anchor positions Mermaid renders
+/// (otherwise root edges anchor closer to the visible circle than they do
+/// in Mermaid JS, breaking the uniform-gap visual).
 fn clip_to_rect(
     node: &NodeLayout,
     center: (f32, f32),
     outside: (f32, f32),
 ) -> (f32, f32) {
-    let dx = outside.0 - center.0;
-    let dy = outside.1 - center.1;
-    let len = (dx * dx + dy * dy).sqrt();
-    if len < 1e-3 {
-        return center;
+    if node.width == 0.0 || node.height == 0.0 {
+        return outside;
     }
-    let nx = dx / len;
-    let ny = dy / len;
-    let half_w = node.width / 2.0;
-    let half_h = node.height / 2.0;
-    let tx = if nx.abs() > 1e-6 {
-        half_w / nx.abs()
+    let x = center.0;
+    let y = center.1;
+    let inside = center;
+    let w = node.width / 2.0;
+    let h = node.height / 2.0;
+    let big_q = (outside.1 - inside.1).abs();
+    let big_r = (outside.0 - inside.0).abs();
+
+    // Branch on which side of the rect the line crosses first. The
+    // condition `|Δy|·w > |Δx|·h` is equivalent to "the line is steeper than
+    // the rect's diagonal" — i.e., it exits through the top or bottom edge.
+    if (y - outside.1).abs() * w > (x - outside.0).abs() * h {
+        // Top / bottom edge.
+        let q = if inside.1 < outside.1 {
+            outside.1 - h - y
+        } else {
+            y - h - outside.1
+        };
+        let r = if big_q == 0.0 { 0.0 } else { (big_r * q) / big_q };
+        let mut res_x = if inside.0 < outside.0 {
+            inside.0 + r
+        } else {
+            inside.0 - big_r + r
+        };
+        let mut res_y = if inside.1 < outside.1 {
+            inside.1 + big_q - q
+        } else {
+            inside.1 - big_q + q
+        };
+        if r == 0.0 {
+            res_x = outside.0;
+            res_y = outside.1;
+        }
+        if big_r == 0.0 {
+            res_x = outside.0;
+        }
+        if big_q == 0.0 {
+            res_y = outside.1;
+        }
+        (res_x, res_y)
     } else {
-        f32::INFINITY
-    };
-    let ty = if ny.abs() > 1e-6 {
-        half_h / ny.abs()
-    } else {
-        f32::INFINITY
-    };
-    let t = tx.min(ty);
-    (center.0 + nx * t, center.1 + ny * t)
+        // Left / right edge.
+        let r = if inside.0 < outside.0 {
+            outside.0 - w - x
+        } else {
+            x - w - outside.0
+        };
+        let q = if big_r == 0.0 { 0.0 } else { (big_q * r) / big_r };
+        let mut res_x = if inside.0 < outside.0 {
+            inside.0 + big_r - r
+        } else {
+            inside.0 - big_r + r
+        };
+        let mut res_y = if inside.1 < outside.1 {
+            inside.1 + q
+        } else {
+            inside.1 - q
+        };
+        if r == 0.0 {
+            res_x = outside.0;
+            res_y = outside.1;
+        }
+        if big_r == 0.0 {
+            res_x = outside.0;
+        }
+        if big_q == 0.0 {
+            res_y = outside.1;
+        }
+        (res_x, res_y)
+    }
 }
 
 /// Run the tidy-tree algorithm over a forest rooted at the given children.
@@ -592,32 +644,42 @@ fn layout_horizontal_subtrees(
     // Translate & rotate: tidy.x is the position along the perpendicular to
     // the growth axis, tidy.y the depth. After 90° rotation the depth becomes
     // horizontal distance from the root edge and tidy.x becomes vertical center.
-    let mut min_center_y = f32::MAX;
-    let mut max_center_y = f32::MIN;
-    let mut raw: Vec<(String, f32, f32, f32)> = Vec::new();
+    //
+    // Center the resulting tree using *only* the first-level subtree roots'
+    // y span — matching Mermaid JS's `combineAndPositionTrees`, which picks
+    // `treeCenterY` from the children of the virtual root rather than from
+    // every descendant. This keeps each first-level child near the global
+    // root's center y so the curved edges leaving the root stay short and
+    // their gap to the root shape stays uniform.
+    let mut first_level_min_y = f32::MAX;
+    let mut first_level_max_y = f32::MIN;
+    let mut raw: Vec<(String, f32, f32)> = Vec::new();
     for (idx, id) in id_lookup.iter().enumerate() {
         if id.is_empty() || idx == virt {
             continue;
         }
         let n = &arena.nodes[idx];
-        // Center in the transposed frame:
         let center_along = n.x + n.w / 2.0; // → vertical center after rotation
         let depth_offset = n.y;             // → horizontal distance from root edge
-        // Width/height in original frame:
         let original_height = (n.w - vertical_gap).max(0.0);
-        let original_width = (n.h - horizontal_gap).max(0.0);
-        let _ = original_width;
-        min_center_y = min_center_y.min(center_along - original_height / 2.0);
-        max_center_y = max_center_y.max(center_along + original_height / 2.0);
-        raw.push((id.clone(), depth_offset, center_along, original_height));
+        if depth_offset < 1e-3 {
+            // First-level subtree root in the rotated frame.
+            first_level_min_y = first_level_min_y.min(center_along - original_height / 2.0);
+            first_level_max_y = first_level_max_y.max(center_along + original_height / 2.0);
+        }
+        raw.push((id.clone(), depth_offset, center_along));
     }
 
     if raw.is_empty() {
         return Vec::new();
     }
-    let mid = (min_center_y + max_center_y) / 2.0;
+    let mid = if first_level_min_y == f32::MAX {
+        0.0
+    } else {
+        (first_level_min_y + first_level_max_y) / 2.0
+    };
     raw.into_iter()
-        .map(|(id, dx, cy, _h)| (id, dx, cy - mid))
+        .map(|(id, dx, cy)| (id, dx, cy - mid))
         .collect()
 }
 

--- a/src/layout/mindmap.rs
+++ b/src/layout/mindmap.rs
@@ -1,5 +1,496 @@
 use super::*;
 
+mod tidy_tree {
+    /// Port of the `non-layered-tidy-tree-layout` algorithm by A. J. van der Ploeg /
+    /// J. van Roosmalen used by Mermaid JS for the `tidy-tree` mindmap layout.
+    /// Indices into `Arena::nodes` are used in place of the original linked-list
+    /// pointers so the structure can live in a single vector.
+    pub struct TidyNode {
+        pub w: f32,
+        pub h: f32,
+        pub y: f32,
+        pub children: Vec<usize>,
+        pub x: f32,
+        prelim: f32,
+        modf: f32,
+        shift: f32,
+        change: f32,
+        tl: Option<usize>,
+        tr: Option<usize>,
+        el: Option<usize>,
+        er: Option<usize>,
+        msel: f32,
+        mser: f32,
+    }
+
+    pub struct Arena {
+        pub nodes: Vec<TidyNode>,
+    }
+
+    impl Arena {
+        pub fn new() -> Self {
+            Self { nodes: Vec::new() }
+        }
+
+        pub fn alloc(&mut self, w: f32, h: f32, y: f32, children: Vec<usize>) -> usize {
+            let idx = self.nodes.len();
+            self.nodes.push(TidyNode {
+                w,
+                h,
+                y,
+                children,
+                x: 0.0,
+                prelim: 0.0,
+                modf: 0.0,
+                shift: 0.0,
+                change: 0.0,
+                tl: None,
+                tr: None,
+                el: None,
+                er: None,
+                msel: 0.0,
+                mser: 0.0,
+            });
+            idx
+        }
+    }
+
+    fn bottom(arena: &Arena, t: usize) -> f32 {
+        arena.nodes[t].y + arena.nodes[t].h
+    }
+
+    fn set_extremes(arena: &mut Arena, t: usize) {
+        let cs = arena.nodes[t].children.len();
+        if cs == 0 {
+            arena.nodes[t].el = Some(t);
+            arena.nodes[t].er = Some(t);
+            arena.nodes[t].msel = 0.0;
+            arena.nodes[t].mser = 0.0;
+        } else {
+            let first = arena.nodes[t].children[0];
+            let last = arena.nodes[t].children[cs - 1];
+            arena.nodes[t].el = arena.nodes[first].el;
+            arena.nodes[t].msel = arena.nodes[first].msel;
+            arena.nodes[t].er = arena.nodes[last].er;
+            arena.nodes[t].mser = arena.nodes[last].mser;
+        }
+    }
+
+    fn next_left_contour(arena: &Arena, t: usize) -> Option<usize> {
+        if arena.nodes[t].children.is_empty() {
+            arena.nodes[t].tl
+        } else {
+            Some(arena.nodes[t].children[0])
+        }
+    }
+
+    fn next_right_contour(arena: &Arena, t: usize) -> Option<usize> {
+        let cs = arena.nodes[t].children.len();
+        if cs == 0 {
+            arena.nodes[t].tr
+        } else {
+            Some(arena.nodes[t].children[cs - 1])
+        }
+    }
+
+    fn distribute_extra(arena: &mut Arena, t: usize, i: usize, si: usize, distance: f32) {
+        if si + 1 != i {
+            let nr = (i - si) as f32;
+            let mid = arena.nodes[t].children[si + 1];
+            let target = arena.nodes[t].children[i];
+            arena.nodes[mid].shift += distance / nr;
+            arena.nodes[target].shift -= distance / nr;
+            arena.nodes[target].change -= distance - distance / nr;
+        }
+    }
+
+    fn move_subtree(arena: &mut Arena, t: usize, i: usize, si: usize, distance: f32) {
+        let child = arena.nodes[t].children[i];
+        arena.nodes[child].modf += distance;
+        arena.nodes[child].msel += distance;
+        arena.nodes[child].mser += distance;
+        distribute_extra(arena, t, i, si, distance);
+    }
+
+    fn set_left_thread(arena: &mut Arena, t: usize, i: usize, cl: usize, modsumcl: f32) {
+        let first = arena.nodes[t].children[0];
+        let li = arena.nodes[first].el.unwrap();
+        arena.nodes[li].tl = Some(cl);
+        let diff = (modsumcl - arena.nodes[cl].modf) - arena.nodes[first].msel;
+        arena.nodes[li].modf += diff;
+        arena.nodes[li].prelim -= diff;
+        let target = arena.nodes[t].children[i];
+        arena.nodes[first].el = arena.nodes[target].el;
+        arena.nodes[first].msel = arena.nodes[target].msel;
+    }
+
+    fn set_right_thread(arena: &mut Arena, t: usize, i: usize, sr: usize, modsumsr: f32) {
+        let cur = arena.nodes[t].children[i];
+        let prev = arena.nodes[t].children[i - 1];
+        let ri = arena.nodes[cur].er.unwrap();
+        arena.nodes[ri].tr = Some(sr);
+        let diff = (modsumsr - arena.nodes[sr].modf) - arena.nodes[cur].mser;
+        arena.nodes[ri].modf += diff;
+        arena.nodes[ri].prelim -= diff;
+        arena.nodes[cur].er = arena.nodes[prev].er;
+        arena.nodes[cur].mser = arena.nodes[prev].mser;
+    }
+
+    fn separate(arena: &mut Arena, t: usize, i: usize, ih_stack: &mut Vec<(f32, usize)>) {
+        let mut sr = Some(arena.nodes[t].children[i - 1]);
+        let mut mssr = arena.nodes[sr.unwrap()].modf;
+        let mut cl = Some(arena.nodes[t].children[i]);
+        let mut mscl = arena.nodes[cl.unwrap()].modf;
+        while let (Some(srv), Some(clv)) = (sr, cl) {
+            if bottom(arena, srv) > ih_stack.last().unwrap().0 {
+                ih_stack.pop();
+            }
+            let distance =
+                mssr + arena.nodes[srv].prelim + arena.nodes[srv].w
+                    - (mscl + arena.nodes[clv].prelim);
+            if distance > 0.0 {
+                mscl += distance;
+                let ih_index = ih_stack.last().unwrap().1;
+                move_subtree(arena, t, i, ih_index, distance);
+            }
+            let sy = bottom(arena, srv);
+            let cy = bottom(arena, clv);
+            if sy <= cy {
+                sr = next_right_contour(arena, srv);
+                if let Some(s) = sr {
+                    mssr += arena.nodes[s].modf;
+                }
+            }
+            if sy >= cy {
+                cl = next_left_contour(arena, clv);
+                if let Some(c) = cl {
+                    mscl += arena.nodes[c].modf;
+                }
+            }
+        }
+        if sr.is_none() && cl.is_some() {
+            set_left_thread(arena, t, i, cl.unwrap(), mscl);
+        } else if sr.is_some() && cl.is_none() {
+            set_right_thread(arena, t, i, sr.unwrap(), mssr);
+        }
+    }
+
+    fn position_root(arena: &mut Arena, t: usize) {
+        let cs = arena.nodes[t].children.len();
+        let first = arena.nodes[t].children[0];
+        let last = arena.nodes[t].children[cs - 1];
+        let prelim = (arena.nodes[first].prelim
+            + arena.nodes[first].modf
+            + arena.nodes[last].modf
+            + arena.nodes[last].prelim
+            + arena.nodes[last].w)
+            / 2.0
+            - arena.nodes[t].w / 2.0;
+        arena.nodes[t].prelim = prelim;
+    }
+
+    fn first_walk(arena: &mut Arena, t: usize) {
+        let cs = arena.nodes[t].children.len();
+        if cs == 0 {
+            set_extremes(arena, t);
+            return;
+        }
+        let first = arena.nodes[t].children[0];
+        first_walk(arena, first);
+        let mut ih_stack: Vec<(f32, usize)> = Vec::new();
+        let low_y = bottom(arena, arena.nodes[first].el.unwrap());
+        ih_stack.push((low_y, 0));
+        for i in 1..cs {
+            let child = arena.nodes[t].children[i];
+            first_walk(arena, child);
+            let er = arena.nodes[child].er.unwrap();
+            let min_y = bottom(arena, er);
+            separate(arena, t, i, &mut ih_stack);
+            // updateIYL: pop hidden then push (min_y, i)
+            while let Some(&(low_y, _)) = ih_stack.last() {
+                if min_y >= low_y {
+                    ih_stack.pop();
+                } else {
+                    break;
+                }
+            }
+            ih_stack.push((min_y, i));
+        }
+        position_root(arena, t);
+        set_extremes(arena, t);
+    }
+
+    fn add_child_spacing(arena: &mut Arena, t: usize) {
+        let cs = arena.nodes[t].children.len();
+        let mut d = 0.0;
+        let mut modsumdelta = 0.0;
+        for i in 0..cs {
+            let c = arena.nodes[t].children[i];
+            d += arena.nodes[c].shift;
+            modsumdelta += d + arena.nodes[c].change;
+            arena.nodes[c].modf += modsumdelta;
+        }
+    }
+
+    fn second_walk(arena: &mut Arena, t: usize, modsum: f32) {
+        let modsum = modsum + arena.nodes[t].modf;
+        arena.nodes[t].x = arena.nodes[t].prelim + modsum;
+        add_child_spacing(arena, t);
+        let cs = arena.nodes[t].children.len();
+        for i in 0..cs {
+            let c = arena.nodes[t].children[i];
+            second_walk(arena, c, modsum);
+        }
+    }
+
+    pub fn layout(arena: &mut Arena, root: usize) {
+        first_walk(arena, root);
+        second_walk(arena, root, 0.0);
+    }
+}
+
+fn place_radial_layout(
+    root_id: &str,
+    info_map: &HashMap<String, MindmapNodeInfo>,
+    nodes: &mut BTreeMap<String, NodeLayout>,
+    horizontal_gap: f32,
+    vertical_gap: f32,
+) {
+    let mut subtree_heights: HashMap<String, f32> = HashMap::new();
+    mindmap_subtree_height(root_id, info_map, nodes, &mut subtree_heights, vertical_gap);
+    let root_center = (0.0_f32, 0.0_f32);
+    if let Some(root_node) = nodes.get_mut(root_id) {
+        root_node.x = root_center.0 - root_node.width / 2.0;
+        root_node.y = root_center.1 - root_node.height / 2.0;
+    }
+    let mut left_children: Vec<String> = Vec::new();
+    let mut right_children: Vec<String> = Vec::new();
+    if let Some(info) = info_map.get(root_id) {
+        for child_id in &info.children {
+            let section = info_map
+                .get(child_id)
+                .and_then(|child| child.section)
+                .unwrap_or(0);
+            if section.is_multiple_of(2) {
+                right_children.push(child_id.clone());
+            } else {
+                left_children.push(child_id.clone());
+            }
+        }
+    }
+    let root_width = nodes.get(root_id).map(|n| n.width).unwrap_or(0.0);
+
+    place_mindmap_children(
+        &right_children,
+        1.0,
+        root_center,
+        root_width,
+        info_map,
+        nodes,
+        &subtree_heights,
+        horizontal_gap,
+        vertical_gap,
+    );
+    place_mindmap_children(
+        &left_children,
+        -1.0,
+        root_center,
+        root_width,
+        info_map,
+        nodes,
+        &subtree_heights,
+        horizontal_gap,
+        vertical_gap,
+    );
+}
+
+/// Lay out a mindmap using the non-layered tidy-tree algorithm. When
+/// `lr_only` is true, every branch grows to the right of the root (matching
+/// the requested `lr-tree` algorithm). Otherwise children alternate between
+/// the left and right halves like Mermaid JS's `tidy-tree` algorithm.
+fn place_tidy_tree(
+    root_id: &str,
+    info_map: &HashMap<String, MindmapNodeInfo>,
+    nodes: &mut BTreeMap<String, NodeLayout>,
+    horizontal_gap: f32,
+    vertical_gap: f32,
+    lr_only: bool,
+) {
+    let root_center = (0.0_f32, 0.0_f32);
+    let root_width = nodes.get(root_id).map(|n| n.width).unwrap_or(0.0);
+
+    if let Some(root_node) = nodes.get_mut(root_id) {
+        root_node.x = root_center.0 - root_node.width / 2.0;
+        root_node.y = root_center.1 - root_node.height / 2.0;
+    }
+
+    let Some(info) = info_map.get(root_id) else {
+        return;
+    };
+
+    let mut left_children: Vec<String> = Vec::new();
+    let mut right_children: Vec<String> = Vec::new();
+    if lr_only {
+        right_children = info.children.clone();
+    } else {
+        for (idx, child_id) in info.children.iter().enumerate() {
+            if idx.is_multiple_of(2) {
+                left_children.push(child_id.clone());
+            } else {
+                right_children.push(child_id.clone());
+            }
+        }
+    }
+
+    let h_gap = horizontal_gap.max(1.0);
+    let v_gap = vertical_gap.max(1.0);
+
+    if !right_children.is_empty() {
+        let positions = layout_horizontal_subtrees(
+            &right_children,
+            info_map,
+            nodes,
+            h_gap,
+            v_gap,
+        );
+        let edge_x = root_center.0 + root_width / 2.0 + h_gap;
+        for (id, dx, cy) in positions {
+            if let Some(node) = nodes.get_mut(&id) {
+                node.x = edge_x + dx;
+                node.y = root_center.1 + cy - node.height / 2.0;
+            }
+        }
+    }
+
+    if !left_children.is_empty() {
+        let positions = layout_horizontal_subtrees(
+            &left_children,
+            info_map,
+            nodes,
+            h_gap,
+            v_gap,
+        );
+        let edge_x = root_center.0 - root_width / 2.0 - h_gap;
+        for (id, dx, cy) in positions {
+            if let Some(node) = nodes.get_mut(&id) {
+                node.x = edge_x - dx - node.width;
+                node.y = root_center.1 + cy - node.height / 2.0;
+            }
+        }
+    }
+}
+
+/// Run the tidy-tree algorithm over a forest rooted at the given children.
+/// Returns triples of `(node id, depth offset from root edge, vertical center)`
+/// in the original (un-rotated) frame so the caller can place the nodes either
+/// side of the root.
+fn layout_horizontal_subtrees(
+    roots: &[String],
+    info_map: &HashMap<String, MindmapNodeInfo>,
+    nodes: &BTreeMap<String, NodeLayout>,
+    horizontal_gap: f32,
+    vertical_gap: f32,
+) -> Vec<(String, f32, f32)> {
+    let mut arena = tidy_tree::Arena::new();
+    let mut id_lookup: Vec<String> = Vec::new();
+
+    fn build(
+        arena: &mut tidy_tree::Arena,
+        id_lookup: &mut Vec<String>,
+        node_id: &str,
+        info_map: &HashMap<String, MindmapNodeInfo>,
+        nodes: &BTreeMap<String, NodeLayout>,
+        horizontal_gap: f32,
+        vertical_gap: f32,
+        depth_y: f32,
+    ) -> usize {
+        let (w, h) = nodes
+            .get(node_id)
+            .map(|n| (n.width, n.height))
+            .unwrap_or((10.0, 10.0));
+        // Tidy-tree expects vertical trees; transpose so the rendered tree
+        // grows horizontally. Width/height are also padded by gap so the
+        // algorithm leaves room for sibling spacing.
+        let tt_w = h + vertical_gap;
+        let tt_h = w + horizontal_gap;
+        let children = info_map
+            .get(node_id)
+            .map(|i| i.children.clone())
+            .unwrap_or_default();
+        let mut child_indices = Vec::with_capacity(children.len());
+        for child in &children {
+            let idx = build(
+                arena,
+                id_lookup,
+                child,
+                info_map,
+                nodes,
+                horizontal_gap,
+                vertical_gap,
+                depth_y + tt_h,
+            );
+            child_indices.push(idx);
+        }
+        let idx = arena.alloc(tt_w, tt_h, depth_y, child_indices);
+        debug_assert_eq!(idx, id_lookup.len());
+        id_lookup.push(node_id.to_string());
+        idx
+    }
+
+    let mut child_indices = Vec::with_capacity(roots.len());
+    for root in roots {
+        let idx = build(
+            &mut arena,
+            &mut id_lookup,
+            root,
+            info_map,
+            nodes,
+            horizontal_gap,
+            vertical_gap,
+            0.0,
+        );
+        child_indices.push(idx);
+    }
+
+    // Virtual super-root with negligible footprint so the tidy algorithm
+    // arranges multiple top-level subtrees together.
+    let virt = arena.alloc(0.0, 0.0, -1.0, child_indices);
+    id_lookup.push(String::new());
+
+    tidy_tree::layout(&mut arena, virt);
+
+    // Translate & rotate: tidy.x is the position along the perpendicular to
+    // the growth axis, tidy.y the depth. After 90° rotation the depth becomes
+    // horizontal distance from the root edge and tidy.x becomes vertical center.
+    let mut min_center_y = f32::MAX;
+    let mut max_center_y = f32::MIN;
+    let mut raw: Vec<(String, f32, f32, f32)> = Vec::new();
+    for (idx, id) in id_lookup.iter().enumerate() {
+        if id.is_empty() || idx == virt {
+            continue;
+        }
+        let n = &arena.nodes[idx];
+        // Center in the transposed frame:
+        let center_along = n.x + n.w / 2.0; // → vertical center after rotation
+        let depth_offset = n.y;             // → horizontal distance from root edge
+        // Width/height in original frame:
+        let original_height = (n.w - vertical_gap).max(0.0);
+        let original_width = (n.h - horizontal_gap).max(0.0);
+        let _ = original_width;
+        min_center_y = min_center_y.min(center_along - original_height / 2.0);
+        max_center_y = max_center_y.max(center_along + original_height / 2.0);
+        raw.push((id.clone(), depth_offset, center_along, original_height));
+    }
+
+    if raw.is_empty() {
+        return Vec::new();
+    }
+    let mid = (min_center_y + max_center_y) / 2.0;
+    raw.into_iter()
+        .map(|(id, dx, cy, _h)| (id, dx, cy - mid))
+        .collect()
+}
+
 #[derive(Clone)]
 struct MindmapPalette {
     section_fills: Vec<String>,
@@ -307,7 +798,6 @@ pub(super) fn compute_mindmap_layout(
         .root_id
         .clone()
         .or_else(|| graph.mindmap.nodes.first().map(|node| node.id.clone()));
-    let mut subtree_heights: HashMap<String, f32> = HashMap::new();
 
     let mut horizontal_gap = config.mindmap.rank_spacing * config.mindmap.rank_spacing_multiplier;
     let mut vertical_gap = config.mindmap.node_spacing * config.mindmap.node_spacing_multiplier;
@@ -322,58 +812,33 @@ pub(super) fn compute_mindmap_layout(
     horizontal_gap = (horizontal_gap * density_scale).max(theme.font_size * 1.1);
     vertical_gap = (vertical_gap * density_scale).max(theme.font_size * 0.9);
 
+    let algorithm = config.mindmap.layout_algorithm.to_ascii_lowercase();
     if let Some(root_id) = root_id.as_ref() {
-        mindmap_subtree_height(
-            root_id,
-            &info_map,
-            &nodes,
-            &mut subtree_heights,
-            vertical_gap,
-        );
-        let root_center = (0.0_f32, 0.0_f32);
-        if let Some(root_node) = nodes.get_mut(root_id) {
-            root_node.x = root_center.0 - root_node.width / 2.0;
-            root_node.y = root_center.1 - root_node.height / 2.0;
+        match algorithm.as_str() {
+            "tidy-tree" | "tidy_tree" | "tidytree" => place_tidy_tree(
+                root_id,
+                &info_map,
+                &mut nodes,
+                horizontal_gap,
+                vertical_gap,
+                false,
+            ),
+            "lr-tree" | "lr_tree" | "lrtree" => place_tidy_tree(
+                root_id,
+                &info_map,
+                &mut nodes,
+                horizontal_gap,
+                vertical_gap,
+                true,
+            ),
+            _ => place_radial_layout(
+                root_id,
+                &info_map,
+                &mut nodes,
+                horizontal_gap,
+                vertical_gap,
+            ),
         }
-        let mut left_children: Vec<String> = Vec::new();
-        let mut right_children: Vec<String> = Vec::new();
-        if let Some(info) = info_map.get(root_id) {
-            for child_id in &info.children {
-                let section = info_map
-                    .get(child_id)
-                    .and_then(|child| child.section)
-                    .unwrap_or(0);
-                if section.is_multiple_of(2) {
-                    right_children.push(child_id.clone());
-                } else {
-                    left_children.push(child_id.clone());
-                }
-            }
-        }
-        let root_width = nodes.get(root_id).map(|n| n.width).unwrap_or(0.0);
-
-        place_mindmap_children(
-            &right_children,
-            1.0,
-            root_center,
-            root_width,
-            &info_map,
-            &mut nodes,
-            &subtree_heights,
-            horizontal_gap,
-            vertical_gap,
-        );
-        place_mindmap_children(
-            &left_children,
-            -1.0,
-            root_center,
-            root_width,
-            &info_map,
-            &mut nodes,
-            &subtree_heights,
-            horizontal_gap,
-            vertical_gap,
-        );
     }
 
     let mut edges = Vec::new();

--- a/src/layout/mindmap.rs
+++ b/src/layout/mindmap.rs
@@ -474,14 +474,21 @@ fn tidy_tree_edge_points(
     points
 }
 
-/// Clip a line that exits `node` toward `outside` to the node's
-/// axis-aligned bounding rectangle. This is a faithful Rust port of
-/// Mermaid JS's `intersection()` in `mermaid-layout-tidy-tree/src/layout.ts`
-/// — including its quirk where the top/bottom branch returns a point that
-/// does *not* lie on the straight inside→outside line. Reproducing the
-/// quirk is necessary to get the same anchor positions Mermaid renders
-/// (otherwise root edges anchor closer to the visible circle than they do
-/// in Mermaid JS, breaking the uniform-gap visual).
+/// Clip a line that exits `node` toward `outside` to the node's boundary.
+///
+/// For circular nodes (`Circle` / `DoubleCircle`) we use a true
+/// circle-intersection so the anchor lands on the visible circumference at
+/// the angle facing `outside`. This gives uniformly-spaced anchors around
+/// the root for both tidy-tree and lr-tree, rather than the bbox corners
+/// Mermaid JS happens to land on (its renderer attaches a generic
+/// rectangle `intersect` to every shape, but that's a quirk we're free to
+/// improve on without affecting the layout itself).
+///
+/// For every other shape we mirror Mermaid JS's `intersection()` from
+/// `mermaid-layout-tidy-tree/src/layout.ts` verbatim — including its quirk
+/// where the top/bottom branch returns a point that does *not* lie on the
+/// straight inside→outside line. Reproducing that quirk is necessary for
+/// the per-node rectangle anchors to line up with what Mermaid JS renders.
 fn clip_to_rect(
     node: &NodeLayout,
     center: (f32, f32),
@@ -489,6 +496,19 @@ fn clip_to_rect(
 ) -> (f32, f32) {
     if node.width == 0.0 || node.height == 0.0 {
         return outside;
+    }
+    if matches!(
+        node.shape,
+        crate::ir::NodeShape::Circle | crate::ir::NodeShape::DoubleCircle
+    ) {
+        let dx = outside.0 - center.0;
+        let dy = outside.1 - center.1;
+        let len = (dx * dx + dy * dy).sqrt();
+        if len < 1e-3 {
+            return center;
+        }
+        let radius = (node.width.min(node.height)) / 2.0;
+        return (center.0 + dx / len * radius, center.1 + dy / len * radius);
     }
     let x = center.0;
     let y = center.1;

--- a/src/layout/mindmap.rs
+++ b/src/layout/mindmap.rs
@@ -255,7 +255,7 @@ fn place_radial_layout(
     nodes: &mut BTreeMap<String, NodeLayout>,
     horizontal_gap: f32,
     vertical_gap: f32,
-) {
+) -> HashMap<String, MindmapSide> {
     let mut subtree_heights: HashMap<String, f32> = HashMap::new();
     mindmap_subtree_height(root_id, info_map, nodes, &mut subtree_heights, vertical_gap);
     let root_center = (0.0_f32, 0.0_f32);
@@ -302,12 +302,25 @@ fn place_radial_layout(
         horizontal_gap,
         vertical_gap,
     );
+    HashMap::new()
+}
+
+/// Lay out a mindmap using the non-layered tidy-tree algorithm. When
+/// `lr_only` is true, every branch grows to the right of the root (matching
+#[derive(Copy, Clone, Debug)]
+enum MindmapSide {
+    Left,
+    Right,
 }
 
 /// Lay out a mindmap using the non-layered tidy-tree algorithm. When
 /// `lr_only` is true, every branch grows to the right of the root (matching
 /// the requested `lr-tree` algorithm). Otherwise children alternate between
 /// the left and right halves like Mermaid JS's `tidy-tree` algorithm.
+///
+/// Returns a map from each non-root node id to the side of the root it
+/// landed on, so the caller can route edges with the same `curveBasis` style
+/// curves Mermaid JS uses for `tidy-tree` mindmaps.
 fn place_tidy_tree(
     root_id: &str,
     info_map: &HashMap<String, MindmapNodeInfo>,
@@ -315,7 +328,8 @@ fn place_tidy_tree(
     horizontal_gap: f32,
     vertical_gap: f32,
     lr_only: bool,
-) {
+) -> HashMap<String, MindmapSide> {
+    let mut side_map: HashMap<String, MindmapSide> = HashMap::new();
     let root_center = (0.0_f32, 0.0_f32);
     let root_width = nodes.get(root_id).map(|n| n.width).unwrap_or(0.0);
 
@@ -325,7 +339,7 @@ fn place_tidy_tree(
     }
 
     let Some(info) = info_map.get(root_id) else {
-        return;
+        return side_map;
     };
 
     let mut left_children: Vec<String> = Vec::new();
@@ -359,6 +373,7 @@ fn place_tidy_tree(
                 node.x = edge_x + dx;
                 node.y = root_center.1 + cy - node.height / 2.0;
             }
+            side_map.insert(id, MindmapSide::Right);
         }
     }
 
@@ -376,8 +391,60 @@ fn place_tidy_tree(
                 node.x = edge_x - dx - node.width;
                 node.y = root_center.1 + cy - node.height / 2.0;
             }
+            side_map.insert(id, MindmapSide::Left);
         }
     }
+
+    side_map
+}
+
+/// Build the four-point control polyline that Mermaid JS feeds to its
+/// `curveBasis` line generator for tidy-tree edges. The two extra middle
+/// points share the source's and target's `y` respectively, so a B-spline
+/// through them leaves and arrives at the nodes nearly horizontally.
+fn tidy_tree_edge_points(
+    from_layout: &NodeLayout,
+    to_layout: &NodeLayout,
+    side_map: &HashMap<String, MindmapSide>,
+    from_id: &str,
+    to_id: &str,
+) -> Vec<(f32, f32)> {
+    let from_center = (
+        from_layout.x + from_layout.width / 2.0,
+        from_layout.y + from_layout.height / 2.0,
+    );
+    let to_center = (
+        to_layout.x + to_layout.width / 2.0,
+        to_layout.y + to_layout.height / 2.0,
+    );
+    let intersection_shift = 30.0_f32;
+
+    // Side of the *child* (target) determines the growth direction. Edges from
+    // the root inherit that direction.
+    let side = side_map
+        .get(to_id)
+        .copied()
+        .or_else(|| side_map.get(from_id).copied())
+        .unwrap_or(MindmapSide::Right);
+    let direction = match side {
+        MindmapSide::Right => 1.0,
+        MindmapSide::Left => -1.0,
+    };
+
+    // Source intersection point along the side facing the target.
+    let from_edge_x = from_center.0 + direction * from_layout.width / 2.0;
+    let to_edge_x = to_center.0 - direction * to_layout.width / 2.0;
+    let start = (from_edge_x, from_center.1);
+    let mid_a = (
+        from_edge_x + direction * intersection_shift,
+        from_center.1,
+    );
+    let mid_b = (
+        to_edge_x - direction * intersection_shift,
+        to_center.1,
+    );
+    let end = (to_edge_x, to_center.1);
+    vec![start, mid_a, mid_b, end]
 }
 
 /// Run the tidy-tree algorithm over a forest rooted at the given children.
@@ -813,24 +880,32 @@ pub(super) fn compute_mindmap_layout(
     vertical_gap = (vertical_gap * density_scale).max(theme.font_size * 0.9);
 
     let algorithm = config.mindmap.layout_algorithm.to_ascii_lowercase();
+    let mut side_map: HashMap<String, MindmapSide> = HashMap::new();
+    let mut curve_edges = false;
     if let Some(root_id) = root_id.as_ref() {
-        match algorithm.as_str() {
-            "tidy-tree" | "tidy_tree" | "tidytree" => place_tidy_tree(
-                root_id,
-                &info_map,
-                &mut nodes,
-                horizontal_gap,
-                vertical_gap,
-                false,
-            ),
-            "lr-tree" | "lr_tree" | "lrtree" => place_tidy_tree(
-                root_id,
-                &info_map,
-                &mut nodes,
-                horizontal_gap,
-                vertical_gap,
-                true,
-            ),
+        side_map = match algorithm.as_str() {
+            "tidy-tree" | "tidy_tree" | "tidytree" => {
+                curve_edges = true;
+                place_tidy_tree(
+                    root_id,
+                    &info_map,
+                    &mut nodes,
+                    horizontal_gap,
+                    vertical_gap,
+                    false,
+                )
+            }
+            "lr-tree" | "lr_tree" | "lrtree" => {
+                curve_edges = true;
+                place_tidy_tree(
+                    root_id,
+                    &info_map,
+                    &mut nodes,
+                    horizontal_gap,
+                    vertical_gap,
+                    true,
+                )
+            }
             _ => place_radial_layout(
                 root_id,
                 &info_map,
@@ -838,7 +913,7 @@ pub(super) fn compute_mindmap_layout(
                 horizontal_gap,
                 vertical_gap,
             ),
-        }
+        };
     }
 
     let mut edges = Vec::new();
@@ -870,6 +945,11 @@ pub(super) fn compute_mindmap_layout(
             config.mindmap.edge_depth_base_width
                 + config.mindmap.edge_depth_step * (edge_depth as f32 + 1.0),
         );
+        let points = if curve_edges {
+            tidy_tree_edge_points(from_layout, to_layout, &side_map, &edge.from, &edge.to)
+        } else {
+            vec![from_center, to_center]
+        };
         edges.push(EdgeLayout {
             from: edge.from.clone(),
             to: edge.to.clone(),
@@ -879,7 +959,7 @@ pub(super) fn compute_mindmap_layout(
             label_anchor: None,
             start_label_anchor: None,
             end_label_anchor: None,
-            points: vec![from_center, to_center],
+            points,
             directed: false,
             arrow_start: false,
             arrow_end: false,

--- a/src/layout/mindmap.rs
+++ b/src/layout/mindmap.rs
@@ -358,6 +358,11 @@ fn place_tidy_tree(
 
     let h_gap = horizontal_gap.max(1.0);
     let v_gap = vertical_gap.max(1.0);
+    // Mermaid JS's `treeSpacing = rootNode.width / 2 + 30` adds an extra
+    // 30px clearance between the root shape and its first-level children
+    // beyond the regular depth gap, giving the curveBasis edges room to
+    // sweep around the root.
+    let root_extra_pad = 30.0_f32;
 
     if !right_children.is_empty() {
         let positions = layout_horizontal_subtrees(
@@ -367,7 +372,7 @@ fn place_tidy_tree(
             h_gap,
             v_gap,
         );
-        let edge_x = root_center.0 + root_width / 2.0 + h_gap;
+        let edge_x = root_center.0 + root_width / 2.0 + h_gap + root_extra_pad;
         for (id, dx, cy) in positions {
             if let Some(node) = nodes.get_mut(&id) {
                 node.x = edge_x + dx;
@@ -385,7 +390,7 @@ fn place_tidy_tree(
             h_gap,
             v_gap,
         );
-        let edge_x = root_center.0 - root_width / 2.0 - h_gap;
+        let edge_x = root_center.0 - root_width / 2.0 - h_gap - root_extra_pad;
         for (id, dx, cy) in positions {
             if let Some(node) = nodes.get_mut(&id) {
                 node.x = edge_x - dx - node.width;
@@ -401,7 +406,10 @@ fn place_tidy_tree(
 /// Build the four-point control polyline that Mermaid JS feeds to its
 /// `curveBasis` line generator for tidy-tree edges. The two extra middle
 /// points share the source's and target's `y` respectively, so a B-spline
-/// through them leaves and arrives at the nodes nearly horizontally.
+/// through them leaves and arrives at the nodes nearly horizontally. The
+/// start/end points are then clipped to the source/target shape boundary
+/// using the adjacent middle point as the outside reference, matching
+/// Mermaid JS's second-pass intersection in `calculateEdgePositions`.
 fn tidy_tree_edge_points(
     from_layout: &NodeLayout,
     to_layout: &NodeLayout,
@@ -431,20 +439,66 @@ fn tidy_tree_edge_points(
         MindmapSide::Left => -1.0,
     };
 
-    // Source intersection point along the side facing the target.
-    let from_edge_x = from_center.0 + direction * from_layout.width / 2.0;
-    let to_edge_x = to_center.0 - direction * to_layout.width / 2.0;
-    let start = (from_edge_x, from_center.1);
+    // Mid points pushed outward by `intersection_shift` along the growth axis.
     let mid_a = (
-        from_edge_x + direction * intersection_shift,
+        from_center.0 + direction * (from_layout.width / 2.0 + intersection_shift),
         from_center.1,
     );
     let mid_b = (
-        to_edge_x - direction * intersection_shift,
+        to_center.0 - direction * (to_layout.width / 2.0 + intersection_shift),
         to_center.1,
     );
-    let end = (to_edge_x, to_center.1);
+
+    // Endpoints clipped to the source/target shape boundary along the line
+    // toward the adjacent middle point. This spreads root-edge starts around
+    // the circumference instead of stacking them on the horizontal midline.
+    let start = clip_to_shape(from_layout, from_center, mid_a);
+    let end = clip_to_shape(to_layout, to_center, mid_b);
+
     vec![start, mid_a, mid_b, end]
+}
+
+/// Clip a line that exits `node` toward `outside` to the node's shape
+/// boundary. Circles and the default mindmap shape use the inscribed-circle
+/// intersection (matching Mermaid JS's `computeCircleEdgeIntersection`);
+/// every other shape uses an axis-aligned-rectangle intersection.
+fn clip_to_shape(
+    node: &NodeLayout,
+    center: (f32, f32),
+    outside: (f32, f32),
+) -> (f32, f32) {
+    let dx = outside.0 - center.0;
+    let dy = outside.1 - center.1;
+    let len = (dx * dx + dy * dy).sqrt();
+    if len < 1e-3 {
+        return center;
+    }
+    let nx = dx / len;
+    let ny = dy / len;
+    let half_w = node.width / 2.0;
+    let half_h = node.height / 2.0;
+    match node.shape {
+        crate::ir::NodeShape::Circle | crate::ir::NodeShape::DoubleCircle => {
+            let radius = half_w.min(half_h);
+            (center.0 + nx * radius, center.1 + ny * radius)
+        }
+        _ => {
+            // Rectangle intersection: scale the unit vector so it just hits
+            // either the horizontal or vertical edge.
+            let tx = if nx.abs() > 1e-6 {
+                half_w / nx.abs()
+            } else {
+                f32::INFINITY
+            };
+            let ty = if ny.abs() > 1e-6 {
+                half_h / ny.abs()
+            } else {
+                f32::INFINITY
+            };
+            let t = tx.min(ty);
+            (center.0 + nx * t, center.1 + ny * t)
+        }
+    }
 }
 
 /// Run the tidy-tree algorithm over a forest rooted at the given children.
@@ -883,6 +937,12 @@ pub(super) fn compute_mindmap_layout(
     let mut side_map: HashMap<String, MindmapSide> = HashMap::new();
     let mut curve_edges = false;
     if let Some(root_id) = root_id.as_ref() {
+        // Match Mermaid JS's tidy-tree spacing exactly: BoundingBox(20, 40)
+        // for sibling/depth gaps and a +30 root padding via `treeSpacing`.
+        // The tidy algorithm packs efficiently on its own, so we ignore the
+        // density scaling that the radial layout uses.
+        let tidy_h_gap = 40.0_f32;
+        let tidy_v_gap = 20.0_f32;
         side_map = match algorithm.as_str() {
             "tidy-tree" | "tidy_tree" | "tidytree" => {
                 curve_edges = true;
@@ -890,8 +950,8 @@ pub(super) fn compute_mindmap_layout(
                     root_id,
                     &info_map,
                     &mut nodes,
-                    horizontal_gap,
-                    vertical_gap,
+                    tidy_h_gap,
+                    tidy_v_gap,
                     false,
                 )
             }
@@ -901,8 +961,8 @@ pub(super) fn compute_mindmap_layout(
                     root_id,
                     &info_map,
                     &mut nodes,
-                    horizontal_gap,
-                    vertical_gap,
+                    tidy_h_gap,
+                    tidy_v_gap,
                     true,
                 )
             }

--- a/src/render.rs
+++ b/src/render.rs
@@ -969,7 +969,11 @@ pub fn render_svg(layout: &Layout, theme: &Theme, config: &LayoutConfig) -> Stri
             _ => 2.0,
         };
         for (edge_idx, edge) in layout.edges.iter().enumerate() {
-            let d = points_to_path(&edge.points);
+            let d = if layout.kind == crate::ir::DiagramKind::Mindmap && edge.points.len() > 2 {
+                basis_curve_path(&edge.points)
+            } else {
+                points_to_path(&edge.points)
+            };
             let mut stroke = theme.line_color.clone();
             let edge_id = edge_dom_id(edge_idx);
             let (mut dash, mut stroke_width) = match edge.style {
@@ -1565,6 +1569,70 @@ fn points_to_path(points: &[(f32, f32)]) -> String {
     for (x, y) in deduped.iter().skip(1) {
         d.push_str(&format!(" L {:.3},{:.3}", x, y));
     }
+    d
+}
+
+/// Port of d3's `curveBasis` (open uniform cubic B-spline). Given control
+/// points `P0..Pn-1`, emits an SVG path that mirrors d3's output exactly:
+/// `M P0` → `L (5*P0 + P1)/6` → `C (2*Pi-1+Pi)/3, (Pi-1+2*Pi)/3, (Pi-1+4*Pi+Pi+1)/6`
+/// for the interior, finishing with a closing cubic to `(Pn-2 + 5*Pn-1)/6`
+/// and a `L Pn-1`. Used by tidy-tree / lr-tree mindmap edges to match the
+/// curved style Mermaid JS produces.
+fn basis_curve_path(points: &[(f32, f32)]) -> String {
+    let pts = dedupe_points(points);
+    let n = pts.len();
+    if n == 0 {
+        return String::new();
+    }
+    if n == 1 {
+        return format!("M {:.3},{:.3}", pts[0].0, pts[0].1);
+    }
+    if n == 2 {
+        return format!(
+            "M {:.3},{:.3} L {:.3},{:.3}",
+            pts[0].0, pts[0].1, pts[1].0, pts[1].1
+        );
+    }
+    let mut d = format!("M {:.3},{:.3}", pts[0].0, pts[0].1);
+    let p0 = pts[0];
+    let p1 = pts[1];
+    d.push_str(&format!(
+        " L {:.3},{:.3}",
+        (5.0 * p0.0 + p1.0) / 6.0,
+        (5.0 * p0.1 + p1.1) / 6.0
+    ));
+    let mut x0 = p0.0;
+    let mut y0 = p0.1;
+    let mut x1 = p1.0;
+    let mut y1 = p1.1;
+    for i in 2..n {
+        let (x, y) = pts[i];
+        d.push_str(&format!(
+            " C {:.3},{:.3} {:.3},{:.3} {:.3},{:.3}",
+            (2.0 * x0 + x1) / 3.0,
+            (2.0 * y0 + y1) / 3.0,
+            (x0 + 2.0 * x1) / 3.0,
+            (y0 + 2.0 * y1) / 3.0,
+            (x0 + 4.0 * x1 + x) / 6.0,
+            (y0 + 4.0 * y1 + y) / 6.0
+        ));
+        x0 = x1;
+        y0 = y1;
+        x1 = x;
+        y1 = y;
+    }
+    // Closing segment, matching d3's lineEnd for `case 3`: another cubic
+    // pretending the final point is repeated, then a straight line to it.
+    d.push_str(&format!(
+        " C {:.3},{:.3} {:.3},{:.3} {:.3},{:.3}",
+        (2.0 * x0 + x1) / 3.0,
+        (2.0 * y0 + y1) / 3.0,
+        (x0 + 2.0 * x1) / 3.0,
+        (y0 + 2.0 * y1) / 3.0,
+        (x0 + 5.0 * x1) / 6.0,
+        (y0 + 5.0 * y1) / 6.0
+    ));
+    d.push_str(&format!(" L {:.3},{:.3}", x1, y1));
     d
 }
 

--- a/tests/fixtures/mindmap/lr_tree.mmd
+++ b/tests/fixtures/mindmap/lr_tree.mmd
@@ -1,0 +1,14 @@
+%%{init: {"mindmap": {"layoutAlgorithm": "lr-tree"}}}%%
+mindmap
+  root((Project))
+    Frontend
+      React
+      Tailwind
+    Backend
+      Rust
+        Axum
+        SQLx
+      Postgres
+    Ops
+      Docker
+      Kubernetes

--- a/tests/fixtures/mindmap/tidy_tree.mmd
+++ b/tests/fixtures/mindmap/tidy_tree.mmd
@@ -1,0 +1,17 @@
+%%{init: {"mindmap": {"layoutAlgorithm": "tidy-tree"}}}%%
+mindmap
+  root((mindmap))
+    Origins
+      Long history
+      Popularisation
+        British popular psychology author Tony Buzan
+    Research
+      On effectiveness<br/>and features
+      On Automatic creation
+        Uses
+          Creative techniques
+          Strategic planning
+          Argument mapping
+    Tools
+      Pen and paper
+      Mermaid

--- a/tests/layout_suite.rs
+++ b/tests/layout_suite.rs
@@ -365,6 +365,8 @@ fn render_all_fixtures() {
         "journey/basic.mmd",
         "kanban/basic.mmd",
         "mindmap/basic.mmd",
+        "mindmap/tidy_tree.mmd",
+        "mindmap/lr_tree.mmd",
         "packet/basic.mmd",
         "pie/basic.mmd",
         "quadrant/basic.mmd",


### PR DESCRIPTION
Closes part of #77 by honoring `mindmap.layoutAlgorithm` so users can pick between the existing radial layout and two horizontal tree layouts.

## Summary

- `tidy-tree` — bidirectional layout that mirrors Mermaid JS's `tidy-tree` algorithm. Root children are alternated between left/right by index parity and each side is positioned with a Rust port of [`non-layered-tidy-tree-layout`](https://github.com/stetrevor/non-layered-tidy-tree-layout) (van der Ploeg / van Roosmalen), the same library Mermaid JS uses for `tidy-tree` mindmaps.
- `lr-tree` — pure left-to-right tree where every branch grows to the right of the root, useful for document-style mindmaps.
- The previously parsed-but-unused `mindmap.layoutAlgorithm` field is now wired through the JSON init-config plumbing (`merge_init_config`), so:

  ```.mermaid
  %%{init: {"mindmap": {"layoutAlgorithm": "tidy-tree"}}}%%
  mindmap
    root((R))
      A
      B
  ```
  selects the new layout. `lr-tree` works the same way.

## Layout comparison

Same source for all three rows — only the `layoutAlgorithm` config changes:

```txt
mindmap
  root((Mermaid<br/>Renderer))
    Parsing
      Tokenizer
        Lexer
        Token kinds
      Frontmatter
      Init directive
    Layout
      Flowchart
        Ranking
        Routing
        Edge labels
      Mind-map
        Radial
        Tidy tree
        LR tree
      Sequence
    Rendering
      SVG output
      PNG via resvg
    Tooling
      CLI
      Test suite
```

| Layout | mermaid-js | rust-renderer |
| --- | --- | --- |
| default | <img width="1023" height="465" alt="image" src="https://github.com/user-attachments/assets/f24f92df-ddea-421b-b07f-f7fc5881aedd" /> | <img width="1070" height="611" alt="image" src="https://github.com/user-attachments/assets/f33f8316-d94c-4db9-91eb-eab62e0ce805" /> |
| tidy-tree | <img width="1021" height="431" alt="image" src="https://github.com/user-attachments/assets/971dd5fb-3a11-4620-b734-4803da7e5260" /> | <img width="1136" height="431" alt="image" src="https://github.com/user-attachments/assets/c35a5e1d-cc33-4398-adcc-f40fd7b9445b" /> |
| lr-tree | _not supported by mermaid-js_ | <img width="627" height="753" alt="image" src="https://github.com/user-attachments/assets/3a1fafce-75cc-40e9-99f6-709009513c7f" /> |

## Out of scope

Issue #77 also mentions rendering deeper nodes (level 3+) as text on lines without background boxes. That cosmetic change is intentionally left for a follow-up so this PR stays focused on the layout algorithms.

## Test plan

- [x] `cargo build --release`
- [x] `cargo test --test layout_suite` — 5/5 passing, including the two new fixtures
- [x] Rendered `tests/fixtures/mindmap/tidy_tree.mmd` and `tests/fixtures/mindmap/lr_tree.mmd` and verified positions:
  - tidy-tree: root centered, even-indexed children on the left, odd-indexed on the right, subtree extents match expectations.
  - lr-tree: root on the left, all branches grow right, deepest level pushed furthest right.
- [x] Confirmed `tests/fixtures/mindmap/basic.mmd` (default radial) is unchanged.