### PR TITLE
Add DejaVu Sans / Liberation Sans fallback for Linux

### DIFF
--- a/src/theme.rs
+++ b/src/theme.rs
@@ -84,7 +84,7 @@ impl Theme {
         let tertiary_color = "#ECECFF".to_string();
         let pie_colors = default_pie_colors(&primary_color, &secondary_color, &tertiary_color);
         Self {
-            font_family: "'trebuchet ms', verdana, arial, \"Noto Color Emoji\", \"Apple Color Emoji\", \"Segoe UI Emoji\", sans-serif".to_string(),
+            font_family: "'trebuchet ms', verdana, arial, \"DejaVu Sans\", \"Liberation Sans\", sans-serif, \"Noto Color Emoji\", \"Apple Color Emoji\", \"Segoe UI Emoji\"".to_string(),
             font_size: 16.0,
             primary_color,
             primary_text_color: "#333333".to_string(),
@@ -133,7 +133,7 @@ impl Theme {
         let tertiary_color = "#FFFFFF".to_string();
         let pie_colors = default_pie_colors(&primary_color, &secondary_color, &tertiary_color);
         Self {
-            font_family: "Inter, ui-sans-serif, system-ui, -apple-system, \"Segoe UI\", \"Noto Color Emoji\", \"Apple Color Emoji\", \"Segoe UI Emoji\", sans-serif"
+            font_family: "Inter, ui-sans-serif, system-ui, -apple-system, \"Segoe UI\", \"DejaVu Sans\", \"Liberation Sans\", sans-serif, \"Noto Color Emoji\", \"Apple Color Emoji\", \"Segoe UI Emoji\""
                 .to_string(),
             font_size: 14.0,
             primary_color,


### PR DESCRIPTION
# Add DejaVu Sans / Liberation Sans fallback for Linux

## Problem

`resvg`/`usvg`'s bundled `fontdb` (`Database::load_system_fonts()`) **does not honour CSS generic family aliases** (`sans-serif`, `monospace`, etc). It only indexes face names from font directories.

When a downstream consumer (such as [`jcode`](https://github.com/1jehuang/jcode)) renders the SVG produced by `mermaid-rs-renderer` with `usvg`, the `font-family` declared by `Theme::mermaid_default()` and `Theme::modern()` resolves to **no real face on Linux**:

```
'trebuchet ms'        → not installed (Microsoft proprietary)
verdana               → not installed (Microsoft proprietary)
arial                 → not installed (Microsoft proprietary)
"Noto Color Emoji"    → resolves, but is a colour-emoji-only font;
                        ASCII glyphs absent → fallback chain breaks
"Apple Color Emoji"   → not installed (macOS only)
"Segoe UI Emoji"      → not installed (Windows only)
sans-serif            → ignored: usvg's fontdb does not interpret
                        generic CSS families
```

`usvg` therefore drops every `<text>` glyph silently, leaving the rest of the SVG (rects, paths, markers) intact. Downstream this manifests as **diagrams with empty boxes and arrows but no labels**.

Reproduced on Arch Linux x86_64 with `resvg 0.46`, `usvg 0.46`. The `mermaid_default` and `modern` themes are both affected because they share the same fallback structure.

## Fix

Insert `"DejaVu Sans"` and `"Liberation Sans"` between the platform-preferred families and the emoji fonts. Both ship by default on virtually every Linux desktop install (Debian/Ubuntu/Fedora/Arch/openSUSE all have them in their base font packages), and are absent on macOS/Windows so the existing platform-preferred families still win there.

```diff
-font_family: "'trebuchet ms', verdana, arial, \"Noto Color Emoji\", \"Apple Color Emoji\", \"Segoe UI Emoji\", sans-serif".to_string(),
+font_family: "'trebuchet ms', verdana, arial, \"DejaVu Sans\", \"Liberation Sans\", sans-serif, \"Noto Color Emoji\", \"Apple Color Emoji\", \"Segoe UI Emoji\"".to_string(),
```

Same change applied to `Theme::modern()`.

I also moved the emoji fonts to the **end** of the list. They are colour-only fallback fonts intended for actual emoji glyphs, not ASCII labels — they should not appear in the resolution chain before the generic sans-serif fallback, otherwise `usvg` matches the emoji face for the whole label and produces blank glyphs.

## Verification

Direct CLI test (`mmdr`):

```bash
$ ./target/release/mmdr -i test.mmd -o fixed.svg
$ resvg fixed.svg fixed.png   # no warnings (was: "Fallback from Noto Color Emoji to Liberation Mono.")
$ tesseract fixed.png -        # OCR: "Start ... Middle ... End"  (was: blank)
```

Existing tests continue to pass — the test in `default_theme_keeps_emoji_font_fallbacks_in_svg` only asserts that the emoji family names are present in the SVG, which is still true.

## Notes

- This does not change behaviour on macOS/Windows since DejaVu/Liberation are absent there and the platform-preferred families resolve first.
- Bundling `Inter` or another web font in the renderer would be a more invasive alternative; this PR is the minimum-risk change.
- A complementary upstream PR is open against `jcode` (1jehuang/jcode#108) for its own `terminal_theme()` which has the same bug.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/1jehuang/codesmith/mermaid-rs-renderer/pr/80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->