### PR TITLE
Fix timeline event text wrapping

### DIFF
--- a/src/layout/text.rs
+++ b/src/layout/text.rs
@@ -25,8 +25,6 @@ pub(super) fn measure_label_with_font_size(
     wrap: bool,
     font_family: &str,
 ) -> TextBlock {
-    let raw_lines = split_lines(text);
-    let mut lines = Vec::new();
     let fast_metrics = config.fast_text_metrics;
     let max_width_px = max_label_width_px(
         config.max_label_width_chars,
@@ -34,9 +32,24 @@ pub(super) fn measure_label_with_font_size(
         font_family,
         fast_metrics,
     );
+    measure_label_with_max_width(text, font_size, max_width_px, config, wrap, font_family)
+}
+
+pub(super) fn measure_label_with_max_width(
+    text: &str,
+    font_size: f32,
+    max_width: f32,
+    config: &LayoutConfig,
+    wrap: bool,
+    font_family: &str,
+) -> TextBlock {
+    let raw_lines = split_lines(text);
+    let mut lines = Vec::new();
+    let fast_metrics = config.fast_text_metrics;
+    let max_width = max_width.max(1.0);
     for line in raw_lines {
         if wrap {
-            let wrapped = wrap_line(&line, max_width_px, font_size, font_family, fast_metrics);
+            let wrapped = wrap_line(&line, max_width, font_size, font_family, fast_metrics);
             lines.extend(wrapped);
         } else {
             lines.push(line);

--- a/src/layout/timeline.rs
+++ b/src/layout/timeline.rs
@@ -7,10 +7,12 @@ pub(super) fn compute_timeline_layout(
 ) -> Layout {
     let data = &graph.timeline;
     let font_size = theme.font_size;
-    let padding = 30.0;
-    let event_width = 120.0;
-    let event_height = 80.0;
-    let event_spacing = 40.0;
+    let event_font_size = theme.font_size * 0.9;
+    let padding = 30.0_f32;
+    let event_width = 120.0_f32;
+    let min_event_height = 80.0_f32;
+    let event_spacing = 40.0_f32;
+    let event_text_width = (event_width - 16.0).max(1.0);
     let title_height = if data.title.is_some() { 40.0 } else { 0.0 };
     let line_y = padding + title_height + 60.0;
 
@@ -19,37 +21,58 @@ pub(super) fn compute_timeline_layout(
         num_events as f32 * event_width + (num_events - 1) as f32 * event_spacing;
 
     let width = padding * 2.0 + total_events_width;
-    let height = padding * 2.0 + title_height + event_height + 100.0;
 
     let title = data.title.as_ref().map(|t| measure_label(t, theme, config));
 
-    let events: Vec<TimelineEventLayout> = data
-        .events
-        .iter()
-        .enumerate()
-        .map(|(i, event)| {
-            let x = padding + i as f32 * (event_width + event_spacing);
-            let y = line_y + 30.0;
+    let mut max_event_height = min_event_height;
+    let mut events = Vec::with_capacity(data.events.len());
+    for (i, event) in data.events.iter().enumerate() {
+        let x = padding + i as f32 * (event_width + event_spacing);
+        let y = line_y + 30.0;
 
-            let time_block = measure_label(&event.time, theme, config);
-            let event_blocks: Vec<TextBlock> = event
-                .events
-                .iter()
-                .map(|e| measure_label(e, theme, config))
-                .collect();
+        let time_block = measure_label_with_font_size(
+            &event.time,
+            font_size,
+            config,
+            false,
+            theme.font_family.as_str(),
+        );
+        let event_blocks: Vec<TextBlock> = event
+            .events
+            .iter()
+            .map(|e| {
+                measure_label_with_max_width(
+                    e,
+                    event_font_size,
+                    event_text_width,
+                    config,
+                    true,
+                    theme.font_family.as_str(),
+                )
+            })
+            .collect();
 
-            TimelineEventLayout {
-                time: time_block,
-                events: event_blocks,
-                x,
-                y,
-                width: event_width,
-                height: event_height,
-                circle_y: line_y,
-            }
-        })
-        .collect();
+        let time_extra =
+            time_block.lines.len().saturating_sub(1) as f32 * font_size * config.label_line_height;
+        let description_height = event_blocks
+            .iter()
+            .map(|block| block.lines.len() as f32 * event_font_size * config.label_line_height)
+            .sum::<f32>();
+        let event_height = (40.0 + time_extra + description_height + 16.0).max(min_event_height);
+        max_event_height = max_event_height.max(event_height);
 
+        events.push(TimelineEventLayout {
+            time: time_block,
+            events: event_blocks,
+            x,
+            y,
+            width: event_width,
+            height: event_height,
+            circle_y: line_y,
+        });
+    }
+
+    let height = padding * 2.0 + title_height + max_event_height + 100.0;
     let line_start_x = padding;
     let line_end_x = width - padding;
 

--- a/src/render.rs
+++ b/src/render.rs
@@ -3774,23 +3774,39 @@ fn render_timeline(
         ));
 
         // Time label (bold, at top of box)
-        svg.push_str(&format!(
-            "<text x=\"{:.2}\" y=\"{:.2}\" text-anchor=\"middle\" font-family=\"{}\" font-size=\"{:.1}\" font-weight=\"bold\" fill=\"{}\">{}</text>",
-            center_x, event.y + 20.0,
-            normalize_font_family(&theme.font_family), theme.font_size,
-            theme.primary_text_color, escape_xml(&event.time.lines.join(" "))
+        svg.push_str(&text_block_svg_with_font_size_weight(
+            center_x,
+            event.y + 20.0,
+            &event.time,
+            theme,
+            config,
+            theme.font_size,
+            "middle",
+            Some(theme.primary_text_color.as_str()),
+            Some("bold"),
+            true,
         ));
 
         // Event descriptions
-        let mut y_offset = 40.0;
+        let time_extra = event.time.lines.len().saturating_sub(1) as f32
+            * theme.font_size
+            * config.label_line_height;
+        let mut text_y = event.y + 40.0 + time_extra;
+        let event_font_size = theme.font_size * 0.9;
+        let event_line_height = event_font_size * config.label_line_height;
         for evt in &event.events {
-            svg.push_str(&format!(
-                "<text x=\"{:.2}\" y=\"{:.2}\" text-anchor=\"middle\" font-family=\"{}\" font-size=\"{:.1}\" fill=\"{}\">{}</text>",
-                center_x, event.y + y_offset,
-                normalize_font_family(&theme.font_family), theme.font_size * 0.9,
-                theme.primary_text_color, escape_xml(&evt.lines.join(" "))
+            svg.push_str(&text_block_svg_with_font_size(
+                center_x,
+                text_y,
+                evt,
+                theme,
+                config,
+                event_font_size,
+                "middle",
+                Some(theme.primary_text_color.as_str()),
+                true,
             ));
-            y_offset += theme.font_size * 1.2;
+            text_y += evt.lines.len() as f32 * event_line_height;
         }
     }
 

--- a/tests/layout_suite.rs
+++ b/tests/layout_suite.rs
@@ -412,6 +412,54 @@ fn render_all_fixtures() {
 }
 
 #[test]
+fn timeline_event_descriptions_wrap_inside_cards() {
+    let input = r#"timeline
+    title Timeline of Industrial Revolution
+    Industry 1.0 : Machinery, Water power, Steam <br>power
+    Industry 2.0 : Electricity, Internal combustion engine, Mass production
+"#;
+    let parsed = parse_mermaid(input).unwrap();
+    let theme = Theme::modern();
+    let config = LayoutConfig::default();
+    let layout = compute_layout(&parsed.graph, &theme, &config);
+    let DiagramData::Timeline(timeline) = &layout.diagram else {
+        panic!("expected timeline layout");
+    };
+
+    let wrapped = timeline
+        .events
+        .iter()
+        .find(|event| event.time.lines.join(" ") == "Industry 2.0")
+        .expect("expected Industry 2.0 event");
+    assert!(
+        wrapped.events[0].lines.len() > 1,
+        "expected long description to wrap: {:?}",
+        wrapped.events[0].lines
+    );
+    assert!(
+        wrapped.height > 80.0,
+        "event card height should expand for wrapped descriptions"
+    );
+
+    let explicit_break = timeline
+        .events
+        .iter()
+        .find(|event| event.time.lines.join(" ") == "Industry 1.0")
+        .expect("expected Industry 1.0 event");
+    assert!(
+        explicit_break.events[0]
+            .lines
+            .iter()
+            .any(|line| line == "power"),
+        "expected explicit <br> to survive as a separate rendered line"
+    );
+
+    let svg = render_svg(&layout, &theme, &config);
+    assert!(!svg.contains(">Electricity, Internal combustion engine, Mass production</text>"));
+    assert!(svg.contains(">power</tspan>"));
+}
+
+#[test]
 fn pie_outside_labels_do_not_intrude_into_right_legend() {
     let input = r#"pie
 "Dogs" : 386


### PR DESCRIPTION
## Summary
- Closes #81.
- Measure timeline event descriptions against the available event-card text width instead of the global label width.
- Render timeline labels through multi-line text helpers so wrapped lines and explicit `<br>` breaks are preserved, with event cards expanding vertically as needed.

## Visual comparison

Before:

<img width="624" height="210" alt="image" src="https://github.com/user-attachments/assets/9ee7f887-05e2-45f0-858f-4d52e8bd1f9e" />

After:

<img width="699" height="307" alt="image" src="https://github.com/user-attachments/assets/11d9aba5-5292-413c-beeb-099755723be3" />


## Test plan
- [x] `cargo fmt -- --check`
- [x] `cargo test timeline_event_descriptions_wrap_inside_cards`
- [x] `cargo test --test layout_suite`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/1jehuang/codesmith/mermaid-rs-renderer/pr/82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->