### PR TITLE
Fix dense flowchart route directness

### DIFF
--- a/src/layout/flowchart/edge_pipeline.rs
+++ b/src/layout/flowchart/edge_pipeline.rs
@@ -646,6 +646,9 @@ pub(in crate::layout) fn build_routed_edges(ctx: RoutedEdgeBuildContext<'_>) -> 
             label_obstacles,
             config,
         );
+    let has_any_edge_label = edge_route_labels.iter().any(Option::is_some)
+        || edge_start_labels.iter().any(Option::is_some)
+        || edge_end_labels.iter().any(Option::is_some);
     let mut existing_segments: Vec<Segment> = Vec::new();
     let mut label_anchors: Vec<Option<(f32, f32)>> = vec![None; graph.edges.len()];
     for (_, _, _, idx) in &route_order {
@@ -753,6 +756,8 @@ pub(in crate::layout) fn build_routed_edges(ctx: RoutedEdgeBuildContext<'_>) -> 
             preferred_label_clearance,
             force_preferred_label_via: graph.kind != DiagramKind::Flowchart,
             coarse_grid_retry: graph.kind == DiagramKind::Flowchart,
+            allow_unoffset_route_candidate: graph.kind == DiagramKind::Flowchart
+                && !has_any_edge_label,
         };
         let use_existing_for_edge = !(matches!(graph.kind, DiagramKind::Class | DiagramKind::Er)
             && edge.style == crate::ir::EdgeStyle::Dotted);
@@ -793,6 +798,7 @@ pub(in crate::layout) fn build_routed_edges(ctx: RoutedEdgeBuildContext<'_>) -> 
                 preferred_label_clearance: route_ctx.preferred_label_clearance,
                 force_preferred_label_via: route_ctx.force_preferred_label_via,
                 coarse_grid_retry: route_ctx.coarse_grid_retry,
+                allow_unoffset_route_candidate: route_ctx.allow_unoffset_route_candidate,
             };
             let fast_points = route_edge_with_avoidance(&fast_ctx, None, None, existing_for_edge);
             let fast_hits = path_obstacle_intersections(

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -2318,6 +2318,7 @@ flowchart LR
             preferred_label_clearance: 0.0,
             force_preferred_label_via: true,
             coarse_grid_retry: true,
+            allow_unoffset_route_candidate: false,
         };
         let mut occupancy = EdgeOccupancy::new(
             config.node_spacing.max(MIN_NODE_SPACING_FLOOR) * EDGE_OCCUPANCY_CELL_RATIO,
@@ -2365,6 +2366,7 @@ flowchart LR
             preferred_label_clearance: 0.0,
             force_preferred_label_via: true,
             coarse_grid_retry: true,
+            allow_unoffset_route_candidate: false,
         };
         let points = route_edge_with_avoidance(&ctx, None, None, None);
         assert!(!points.is_empty());
@@ -2412,6 +2414,7 @@ flowchart LR
             preferred_label_clearance: 0.0,
             force_preferred_label_via: true,
             coarse_grid_retry: true,
+            allow_unoffset_route_candidate: false,
         };
         let start = anchor_point_for_node(&from, EdgeSide::Right, 0.0);
         let end = anchor_point_for_node(&to, EdgeSide::Left, 0.0);
@@ -2484,6 +2487,7 @@ flowchart LR
             preferred_label_clearance: 0.0,
             force_preferred_label_via: true,
             coarse_grid_retry: true,
+            allow_unoffset_route_candidate: false,
         };
         let points = route_edge_with_avoidance(&ctx, None, None, None);
         let dist = polyline_point_distance(&points, preferred);
@@ -2533,6 +2537,7 @@ flowchart LR
             preferred_label_clearance: clearance,
             force_preferred_label_via: false,
             coarse_grid_retry: true,
+            allow_unoffset_route_candidate: false,
         };
         let points = route_edge_with_avoidance(&ctx, None, None, None);
         let label_corridor = Obstacle {

--- a/src/layout/routing.rs
+++ b/src/layout/routing.rs
@@ -413,6 +413,7 @@ pub(super) struct RouteContext<'a> {
     pub(super) preferred_label_clearance: f32,
     pub(super) force_preferred_label_via: bool,
     pub(super) coarse_grid_retry: bool,
+    pub(super) allow_unoffset_route_candidate: bool,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -1879,6 +1880,9 @@ pub(super) fn route_edge_with_avoidance(
     // Fall back to orthogonal routing with control points
     let step = ctx.config.node_spacing.max(ORTHO_STEP_MIN_SPACING) * ROUTING_PAD_RATIO;
     let mut offsets = vec![ctx.base_offset];
+    if ctx.base_offset.abs() > 1e-3 && ctx.allow_unoffset_route_candidate {
+        offsets.push(0.0);
+    }
     for i in 1..=6 {
         let delta = step * i as f32;
         offsets.push(ctx.base_offset + delta);


### PR DESCRIPTION
## Summary
- Closes #84.
- Adds an unlabeled-flowchart routing option that considers the unoffset centerline in addition to lane-offset candidates.
- Keeps the new candidate disabled for graphs with edge labels so label-reservation routing remains unchanged.

## Test plan
- [x] `cargo test dense_flowchart_keeps_mid_span_edge_reasonably_direct`
- [x] `cargo test dense_flowchart`
- [x] `cargo test --test layout_suite`
- [x] `cargo fmt -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] `cargo test --all-targets --all-features` (fails on existing `docs/comparison_sources/flowchart_opaque.mmd` invariant: `edges[8:Baldr->Ke2].label: route overlaps its own center label box`; reproduced on branch baseline before applying this fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/1jehuang/codesmith/mermaid-rs-renderer/pr/85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->