### PR TITLE
Support timeline direction

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -505,11 +505,11 @@ sequenceDiagram
     }
 
     #[test]
-    fn merge_init_config_updates_timeline_direction() {
+    fn merge_init_config_updates_timeline_default_direction() {
         let config = Config::default();
         let init = json!({
             "timeline": {
-                "direction": "TD"
+                "defaultDirection": "TD"
             }
         });
         let merged = merge_init_config(config, init);
@@ -734,7 +734,7 @@ fn merge_init_config(mut config: Config, init: serde_json::Value) -> Config {
     }
     if let Some(direction) = init
         .get("timeline")
-        .and_then(|timeline| timeline.get("direction"))
+        .and_then(|timeline| timeline.get("defaultDirection"))
         .and_then(|v| v.as_str())
     {
         config.layout.timeline.direction = direction.to_ascii_uppercase();

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,5 @@
 use crate::config::{Config, load_config};
+use crate::ir::Direction;
 use crate::layout::compute_layout_with_metrics;
 use crate::layout_dump::write_layout_dump;
 use crate::parser::parse_mermaid;
@@ -503,6 +504,18 @@ sequenceDiagram
         let merged = merge_init_config(config, init);
         assert_eq!(merged.layout.preferred_aspect_ratio, Some(16.0 / 9.0));
     }
+
+    #[test]
+    fn merge_init_config_updates_timeline_direction() {
+        let config = Config::default();
+        let init = json!({
+            "timeline": {
+                "direction": "TD"
+            }
+        });
+        let merged = merge_init_config(config, init);
+        assert_eq!(merged.layout.timeline.direction, "TD");
+    }
 }
 
 fn merge_init_config(mut config: Config, init: serde_json::Value) -> Config {
@@ -719,6 +732,14 @@ fn merge_init_config(mut config: Config, init: serde_json::Value) -> Config {
         if let Some(val) = flowchart.get("portSideBias").and_then(|v| v.as_f64()) {
             config.layout.flowchart.port_side_bias = val as f32;
         }
+    }
+    if let Some(direction) = init
+        .get("timeline")
+        .and_then(|timeline| timeline.get("direction"))
+        .and_then(|v| v.as_str())
+        && Direction::from_timeline_token(direction).is_some()
+    {
+        config.layout.timeline.direction = direction.to_ascii_uppercase();
     }
     if let Some(gitgraph) = init.get("gitGraph") {
         let mut commit_step_set = false;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,4 @@
 use crate::config::{Config, load_config};
-use crate::ir::Direction;
 use crate::layout::compute_layout_with_metrics;
 use crate::layout_dump::write_layout_dump;
 use crate::parser::parse_mermaid;
@@ -737,7 +736,6 @@ fn merge_init_config(mut config: Config, init: serde_json::Value) -> Config {
         .get("timeline")
         .and_then(|timeline| timeline.get("direction"))
         .and_then(|v| v.as_str())
-        && Direction::from_timeline_token(direction).is_some()
     {
         config.layout.timeline.direction = direction.to_ascii_uppercase();
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -753,6 +753,20 @@ pub struct LayoutConfig {
     pub pie: PieConfig,
     pub treemap: TreemapConfig,
     pub flowchart: FlowchartLayoutConfig,
+    pub timeline: TimelineConfig,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TimelineConfig {
+    pub direction: String,
+}
+
+impl Default for TimelineConfig {
+    fn default() -> Self {
+        Self {
+            direction: "LR".to_string(),
+        }
+    }
 }
 
 impl Default for LayoutConfig {
@@ -773,6 +787,7 @@ impl Default for LayoutConfig {
             pie: PieConfig::default(),
             treemap: TreemapConfig::default(),
             flowchart: FlowchartLayoutConfig::default(),
+            timeline: TimelineConfig::default(),
         }
     }
 }
@@ -1449,6 +1464,12 @@ struct TreemapConfigFile {
     icon_ty: Option<f32>,
 }
 
+#[derive(Debug, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+struct TimelineConfigFile {
+    direction: Option<String>,
+}
+
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct ConfigFile {
@@ -1463,6 +1484,7 @@ struct ConfigFile {
     gitgraph: Option<GitGraphConfigFile>,
     c4: Option<C4ConfigFile>,
     treemap: Option<TreemapConfigFile>,
+    timeline: Option<TimelineConfigFile>,
 }
 
 pub fn load_config(path: Option<&Path>) -> anyhow::Result<Config> {
@@ -1818,6 +1840,13 @@ pub fn load_config(path: Option<&Path>) -> anyhow::Result<Config> {
                 config.layout.flowchart.objective.backedge_cross_weight = v;
             }
         }
+    }
+
+    if let Some(timeline) = parsed.timeline
+        && let Some(direction) = timeline.direction.as_deref()
+        && crate::ir::Direction::from_timeline_token(direction).is_some()
+    {
+        config.layout.timeline.direction = direction.to_ascii_uppercase();
     }
 
     if let Some(pie) = parsed.pie {
@@ -2809,5 +2838,14 @@ mod tests {
         );
         assert_eq!(mindmap.root_fill, Some("#444444".to_string()));
         assert_eq!(mindmap.root_text, Some("#555555".to_string()));
+    }
+
+    #[test]
+    fn timeline_config_accepts_direction() {
+        let parsed: ConfigFile = serde_json::from_str(r#"{"timeline":{"direction":"TD"}}"#)
+            .expect("timeline config should parse");
+        let timeline = parsed.timeline.expect("timeline config");
+
+        assert_eq!(timeline.direction.as_deref(), Some("TD"));
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1467,7 +1467,7 @@ struct TreemapConfigFile {
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct TimelineConfigFile {
-    direction: Option<String>,
+    default_direction: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1843,7 +1843,7 @@ pub fn load_config(path: Option<&Path>) -> anyhow::Result<Config> {
     }
 
     if let Some(timeline) = parsed.timeline
-        && let Some(direction) = timeline.direction.as_deref()
+        && let Some(direction) = timeline.default_direction.as_deref()
     {
         config.layout.timeline.direction = direction.to_ascii_uppercase();
     }
@@ -2840,11 +2840,11 @@ mod tests {
     }
 
     #[test]
-    fn timeline_config_accepts_direction() {
-        let parsed: ConfigFile = serde_json::from_str(r#"{"timeline":{"direction":"TD"}}"#)
+    fn timeline_config_accepts_default_direction() {
+        let parsed: ConfigFile = serde_json::from_str(r#"{"timeline":{"defaultDirection":"TD"}}"#)
             .expect("timeline config should parse");
         let timeline = parsed.timeline.expect("timeline config");
 
-        assert_eq!(timeline.direction.as_deref(), Some("TD"));
+        assert_eq!(timeline.default_direction.as_deref(), Some("TD"));
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1844,7 +1844,6 @@ pub fn load_config(path: Option<&Path>) -> anyhow::Result<Config> {
 
     if let Some(timeline) = parsed.timeline
         && let Some(direction) = timeline.direction.as_deref()
-        && crate::ir::Direction::from_timeline_token(direction).is_some()
     {
         config.layout.timeline.direction = direction.to_ascii_uppercase();
     }

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -320,6 +320,15 @@ impl Direction {
             _ => None,
         }
     }
+
+    pub fn from_timeline_token(token: &str) -> Option<Self> {
+        let upper = token.to_ascii_uppercase();
+        match upper.as_str() {
+            "TD" => Some(Self::TopDown),
+            "LR" => Some(Self::LeftRight),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -517,6 +526,7 @@ pub struct TimelineData {
     pub title: Option<String>,
     pub events: Vec<TimelineEvent>,
     pub sections: Vec<String>,
+    pub direction: Option<Direction>,
 }
 
 #[derive(Debug, Clone, Default)]

--- a/src/layout/invariants.rs
+++ b/src/layout/invariants.rs
@@ -545,6 +545,8 @@ pub fn validate_layout_invariants(layout: &Layout) -> Result<(), Vec<LayoutInvar
                 ("timeline.line_y", tl.line_y),
                 ("timeline.line_start_x", tl.line_start_x),
                 ("timeline.line_end_x", tl.line_end_x),
+                ("timeline.line_start_y", tl.line_start_y),
+                ("timeline.line_end_y", tl.line_end_y),
             ] {
                 check_finite(&mut errors, path, value);
             }

--- a/src/layout/text.rs
+++ b/src/layout/text.rs
@@ -25,8 +25,6 @@ pub(super) fn measure_label_with_font_size(
     wrap: bool,
     font_family: &str,
 ) -> TextBlock {
-    let raw_lines = split_lines(text);
-    let mut lines = Vec::new();
     let fast_metrics = config.fast_text_metrics;
     let max_width_px = max_label_width_px(
         config.max_label_width_chars,
@@ -34,9 +32,24 @@ pub(super) fn measure_label_with_font_size(
         font_family,
         fast_metrics,
     );
+    measure_label_with_max_width(text, font_size, max_width_px, config, wrap, font_family)
+}
+
+pub(super) fn measure_label_with_max_width(
+    text: &str,
+    font_size: f32,
+    max_width: f32,
+    config: &LayoutConfig,
+    wrap: bool,
+    font_family: &str,
+) -> TextBlock {
+    let raw_lines = split_lines(text);
+    let mut lines = Vec::new();
+    let fast_metrics = config.fast_text_metrics;
+    let max_width = max_width.max(1.0);
     for line in raw_lines {
         if wrap {
-            let wrapped = wrap_line(&line, max_width_px, font_size, font_family, fast_metrics);
+            let wrapped = wrap_line(&line, max_width, font_size, font_family, fast_metrics);
             lines.extend(wrapped);
         } else {
             lines.push(line);

--- a/src/layout/timeline.rs
+++ b/src/layout/timeline.rs
@@ -1,11 +1,20 @@
 use super::*;
 
+struct MeasuredTimelineEvent {
+    time: TextBlock,
+    events: Vec<TextBlock>,
+    height: f32,
+}
+
 pub(super) fn compute_timeline_layout(
     graph: &Graph,
     theme: &Theme,
     config: &LayoutConfig,
 ) -> Layout {
     let data = &graph.timeline;
+    let direction = data.direction.unwrap_or_else(|| {
+        Direction::from_timeline_token(&config.timeline.direction).unwrap_or(Direction::LeftRight)
+    });
     let font_size = theme.font_size;
     let event_font_size = theme.font_size * 0.9;
     let padding = 30.0_f32;
@@ -14,22 +23,12 @@ pub(super) fn compute_timeline_layout(
     let event_spacing = 40.0_f32;
     let event_text_width = (event_width - 16.0).max(1.0);
     let title_height = if data.title.is_some() { 40.0 } else { 0.0 };
-    let line_y = padding + title_height + 60.0;
-
-    let num_events = data.events.len().max(1);
-    let total_events_width =
-        num_events as f32 * event_width + (num_events - 1) as f32 * event_spacing;
-
-    let width = padding * 2.0 + total_events_width;
 
     let title = data.title.as_ref().map(|t| measure_label(t, theme, config));
 
     let mut max_event_height = min_event_height;
-    let mut events = Vec::with_capacity(data.events.len());
-    for (i, event) in data.events.iter().enumerate() {
-        let x = padding + i as f32 * (event_width + event_spacing);
-        let y = line_y + 30.0;
-
+    let mut measured_events = Vec::with_capacity(data.events.len());
+    for event in &data.events {
         let time_block = measure_label_with_font_size(
             &event.time,
             font_size,
@@ -61,22 +60,91 @@ pub(super) fn compute_timeline_layout(
         let event_height = (40.0 + time_extra + description_height + 16.0).max(min_event_height);
         max_event_height = max_event_height.max(event_height);
 
-        events.push(TimelineEventLayout {
+        measured_events.push(MeasuredTimelineEvent {
             time: time_block,
             events: event_blocks,
-            x,
-            y,
-            width: event_width,
             height: event_height,
-            circle_y: line_y,
         });
     }
 
-    let height = padding * 2.0 + title_height + max_event_height + 100.0;
-    let line_start_x = padding;
-    let line_end_x = width - padding;
+    let (events, width, height, line_y, line_start_x, line_end_x, line_start_y, line_end_y) =
+        if direction == Direction::TopDown {
+            let content_top = padding + title_height + 30.0;
+            let line_x = padding + 20.0;
+            let event_x = line_x + 40.0;
+            let content_height = if measured_events.is_empty() {
+                min_event_height
+            } else {
+                measured_events
+                    .iter()
+                    .map(|event| event.height)
+                    .sum::<f32>()
+                    + (measured_events.len() - 1) as f32 * event_spacing
+            };
+            let width = event_x + event_width + padding;
+            let height = content_top + content_height + padding;
+            let mut y = content_top;
+            let mut events = Vec::with_capacity(measured_events.len());
 
-    // Sections (simplified - just record them)
+            for measured in measured_events {
+                let circle_y = y + measured.height / 2.0;
+                events.push(TimelineEventLayout {
+                    time: measured.time,
+                    events: measured.events,
+                    x: event_x,
+                    y,
+                    width: event_width,
+                    height: measured.height,
+                    circle_y,
+                });
+                y += measured.height + event_spacing;
+            }
+
+            (
+                events,
+                width,
+                height,
+                content_top,
+                line_x,
+                line_x,
+                content_top,
+                content_top + content_height,
+            )
+        } else {
+            let line_y = padding + title_height + 60.0;
+            let num_events = measured_events.len().max(1);
+            let total_events_width =
+                num_events as f32 * event_width + (num_events - 1) as f32 * event_spacing;
+            let width = padding * 2.0 + total_events_width;
+            let height = padding * 2.0 + title_height + max_event_height + 100.0;
+            let mut events = Vec::with_capacity(measured_events.len());
+
+            for (i, measured) in measured_events.into_iter().enumerate() {
+                let x = padding + i as f32 * (event_width + event_spacing);
+                let y = line_y + 30.0;
+                events.push(TimelineEventLayout {
+                    time: measured.time,
+                    events: measured.events,
+                    x,
+                    y,
+                    width: event_width,
+                    height: measured.height,
+                    circle_y: line_y,
+                });
+            }
+
+            (
+                events,
+                width,
+                height,
+                line_y,
+                padding,
+                width - padding,
+                line_y,
+                line_y,
+            )
+        };
+
     let sections: Vec<TimelineSectionLayout> = data
         .sections
         .iter()
@@ -126,9 +194,12 @@ pub(super) fn compute_timeline_layout(
             title_y: padding + font_size,
             events,
             sections,
+            direction,
             line_y,
             line_start_x,
             line_end_x,
+            line_start_y,
+            line_end_y,
             width,
             height,
         }),

--- a/src/layout/timeline.rs
+++ b/src/layout/timeline.rs
@@ -3,6 +3,7 @@ use super::*;
 struct MeasuredTimelineEvent {
     time: TextBlock,
     events: Vec<TextBlock>,
+    width: f32,
     height: f32,
 }
 
@@ -18,10 +19,21 @@ pub(super) fn compute_timeline_layout(
     let font_size = theme.font_size;
     let event_font_size = theme.font_size * 0.9;
     let padding = 30.0_f32;
-    let event_width = 120.0_f32;
-    let min_event_height = 80.0_f32;
+    let min_event_width = 120.0_f32;
+    let max_event_width = if direction == Direction::TopDown {
+        360.0_f32
+    } else {
+        min_event_width
+    };
+    let min_event_height = if direction == Direction::TopDown {
+        0.0_f32
+    } else {
+        80.0_f32
+    };
+    let empty_event_height = 80.0_f32;
     let event_spacing = 40.0_f32;
-    let event_text_width = (event_width - 16.0).max(1.0);
+    let event_text_width = (max_event_width - 16.0).max(1.0);
+    let event_bottom_padding = 8.0_f32;
     let title_height = if data.title.is_some() { 40.0 } else { 0.0 };
 
     let title = data.title.as_ref().map(|t| measure_label(t, theme, config));
@@ -53,16 +65,55 @@ pub(super) fn compute_timeline_layout(
 
         let time_extra =
             time_block.lines.len().saturating_sub(1) as f32 * font_size * config.label_line_height;
-        let description_height = event_blocks
+        let description_line_count = event_blocks
             .iter()
-            .map(|block| block.lines.len() as f32 * event_font_size * config.label_line_height)
-            .sum::<f32>();
-        let event_height = (40.0 + time_extra + description_height + 16.0).max(min_event_height);
+            .map(|block| block.lines.len())
+            .sum::<usize>();
+        let event_width = if direction == Direction::TopDown {
+            let time_width = time_block
+                .lines
+                .iter()
+                .map(|line| {
+                    text_width(
+                        line,
+                        font_size,
+                        theme.font_family.as_str(),
+                        config.fast_text_metrics,
+                    )
+                })
+                .fold(0.0, f32::max);
+            let content_width = event_blocks
+                .iter()
+                .flat_map(|block| block.lines.iter())
+                .map(|line| {
+                    text_width(
+                        line,
+                        event_font_size,
+                        theme.font_family.as_str(),
+                        config.fast_text_metrics,
+                    )
+                })
+                .fold(time_width, f32::max);
+            (content_width + 16.0).clamp(min_event_width, max_event_width)
+        } else {
+            min_event_width
+        };
+        let event_height = if description_line_count == 0 {
+            20.0 + time_extra + font_size * 0.25 + event_bottom_padding
+        } else {
+            let event_line_height = event_font_size * config.label_line_height;
+            40.0 + time_extra
+                + description_line_count.saturating_sub(1) as f32 * event_line_height
+                + event_font_size * 0.25
+                + event_bottom_padding
+        }
+        .max(min_event_height);
         max_event_height = max_event_height.max(event_height);
 
         measured_events.push(MeasuredTimelineEvent {
             time: time_block,
             events: event_blocks,
+            width: event_width,
             height: event_height,
         });
     }
@@ -73,7 +124,7 @@ pub(super) fn compute_timeline_layout(
             let line_x = padding + 20.0;
             let event_x = line_x + 40.0;
             let content_height = if measured_events.is_empty() {
-                min_event_height
+                empty_event_height
             } else {
                 measured_events
                     .iter()
@@ -81,7 +132,11 @@ pub(super) fn compute_timeline_layout(
                     .sum::<f32>()
                     + (measured_events.len() - 1) as f32 * event_spacing
             };
-            let width = event_x + event_width + padding;
+            let content_width = measured_events
+                .iter()
+                .map(|event| event.width)
+                .fold(min_event_width, f32::max);
+            let width = event_x + content_width + padding;
             let height = content_top + content_height + padding;
             let mut y = content_top;
             let mut events = Vec::with_capacity(measured_events.len());
@@ -93,7 +148,7 @@ pub(super) fn compute_timeline_layout(
                     events: measured.events,
                     x: event_x,
                     y,
-                    width: event_width,
+                    width: measured.width,
                     height: measured.height,
                     circle_y,
                 });
@@ -114,20 +169,20 @@ pub(super) fn compute_timeline_layout(
             let line_y = padding + title_height + 60.0;
             let num_events = measured_events.len().max(1);
             let total_events_width =
-                num_events as f32 * event_width + (num_events - 1) as f32 * event_spacing;
+                num_events as f32 * min_event_width + (num_events - 1) as f32 * event_spacing;
             let width = padding * 2.0 + total_events_width;
             let height = padding * 2.0 + title_height + max_event_height + 100.0;
             let mut events = Vec::with_capacity(measured_events.len());
 
             for (i, measured) in measured_events.into_iter().enumerate() {
-                let x = padding + i as f32 * (event_width + event_spacing);
+                let x = padding + i as f32 * (min_event_width + event_spacing);
                 let y = line_y + 30.0;
                 events.push(TimelineEventLayout {
                     time: measured.time,
                     events: measured.events,
                     x,
                     y,
-                    width: event_width,
+                    width: measured.width,
                     height: measured.height,
                     circle_y: line_y,
                 });

--- a/src/layout/timeline.rs
+++ b/src/layout/timeline.rs
@@ -7,10 +7,12 @@ pub(super) fn compute_timeline_layout(
 ) -> Layout {
     let data = &graph.timeline;
     let font_size = theme.font_size;
-    let padding = 30.0;
-    let event_width = 120.0;
-    let event_height = 80.0;
-    let event_spacing = 40.0;
+    let event_font_size = theme.font_size * 0.9;
+    let padding = 30.0_f32;
+    let event_width = 120.0_f32;
+    let min_event_height = 80.0_f32;
+    let event_spacing = 40.0_f32;
+    let event_text_width = (event_width - 16.0).max(1.0);
     let title_height = if data.title.is_some() { 40.0 } else { 0.0 };
     let line_y = padding + title_height + 60.0;
 
@@ -19,37 +21,58 @@ pub(super) fn compute_timeline_layout(
         num_events as f32 * event_width + (num_events - 1) as f32 * event_spacing;
 
     let width = padding * 2.0 + total_events_width;
-    let height = padding * 2.0 + title_height + event_height + 100.0;
 
     let title = data.title.as_ref().map(|t| measure_label(t, theme, config));
 
-    let events: Vec<TimelineEventLayout> = data
-        .events
-        .iter()
-        .enumerate()
-        .map(|(i, event)| {
-            let x = padding + i as f32 * (event_width + event_spacing);
-            let y = line_y + 30.0;
+    let mut max_event_height = min_event_height;
+    let mut events = Vec::with_capacity(data.events.len());
+    for (i, event) in data.events.iter().enumerate() {
+        let x = padding + i as f32 * (event_width + event_spacing);
+        let y = line_y + 30.0;
 
-            let time_block = measure_label(&event.time, theme, config);
-            let event_blocks: Vec<TextBlock> = event
-                .events
-                .iter()
-                .map(|e| measure_label(e, theme, config))
-                .collect();
+        let time_block = measure_label_with_font_size(
+            &event.time,
+            font_size,
+            config,
+            false,
+            theme.font_family.as_str(),
+        );
+        let event_blocks: Vec<TextBlock> = event
+            .events
+            .iter()
+            .map(|e| {
+                measure_label_with_max_width(
+                    e,
+                    event_font_size,
+                    event_text_width,
+                    config,
+                    true,
+                    theme.font_family.as_str(),
+                )
+            })
+            .collect();
 
-            TimelineEventLayout {
-                time: time_block,
-                events: event_blocks,
-                x,
-                y,
-                width: event_width,
-                height: event_height,
-                circle_y: line_y,
-            }
-        })
-        .collect();
+        let time_extra =
+            time_block.lines.len().saturating_sub(1) as f32 * font_size * config.label_line_height;
+        let description_height = event_blocks
+            .iter()
+            .map(|block| block.lines.len() as f32 * event_font_size * config.label_line_height)
+            .sum::<f32>();
+        let event_height = (40.0 + time_extra + description_height + 16.0).max(min_event_height);
+        max_event_height = max_event_height.max(event_height);
 
+        events.push(TimelineEventLayout {
+            time: time_block,
+            events: event_blocks,
+            x,
+            y,
+            width: event_width,
+            height: event_height,
+            circle_y: line_y,
+        });
+    }
+
+    let height = padding * 2.0 + title_height + max_event_height + 100.0;
     let line_start_x = padding;
     let line_end_x = width - padding;
 

--- a/src/layout/types.rs
+++ b/src/layout/types.rs
@@ -365,9 +365,12 @@ pub struct TimelineLayout {
     pub title_y: f32,
     pub events: Vec<TimelineEventLayout>,
     pub sections: Vec<TimelineSectionLayout>,
+    pub direction: crate::ir::Direction,
     pub line_y: f32,
     pub line_start_x: f32,
     pub line_end_x: f32,
+    pub line_start_y: f32,
+    pub line_end_y: f32,
     pub width: f32,
     pub height: f32,
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2088,6 +2088,15 @@ fn parse_journey_task_line(line: &str) -> Option<(String, Option<f32>, Vec<Strin
     Some((label, score, actors))
 }
 
+fn parse_timeline_header_direction(line: &str) -> Option<Direction> {
+    let mut parts = line.split_whitespace();
+    let header = parts.next()?;
+    if !header.eq_ignore_ascii_case("timeline") {
+        return None;
+    }
+    parts.next().and_then(Direction::from_timeline_token)
+}
+
 fn parse_timeline_diagram(input: &str) -> Result<ParseOutput> {
     let mut graph = Graph::new();
     graph.kind = DiagramKind::Timeline;
@@ -2119,6 +2128,10 @@ fn parse_timeline_diagram(input: &str) -> Result<ParseOutput> {
         }
         let lower = line.to_ascii_lowercase();
         if lower.starts_with("timeline") {
+            if let Some(direction) = parse_timeline_header_direction(line) {
+                graph.direction = direction;
+                graph.timeline.direction = Some(direction);
+            }
             continue;
         }
         if lower.starts_with("title") {
@@ -6759,10 +6772,22 @@ A["foo & bar"] & B --> C"#;
         let input = "timeline\n  title History\n  2020 : Launch\n  2021 : Growth";
         let parsed = parse_mermaid(input).unwrap();
         assert_eq!(parsed.graph.kind, DiagramKind::Timeline);
+        assert_eq!(parsed.graph.timeline.direction, None);
         assert_eq!(parsed.graph.timeline.events.len(), 2);
         assert_eq!(parsed.graph.timeline.title.as_deref(), Some("History"));
         assert_eq!(parsed.graph.timeline.events[0].time, "2020");
         assert_eq!(parsed.graph.timeline.events[0].events, vec!["Launch"]);
+    }
+
+    #[test]
+    fn parse_timeline_direction_headers() {
+        let parsed = parse_mermaid("timeline TD\n  2020 : Launch").unwrap();
+        assert_eq!(parsed.graph.direction, Direction::TopDown);
+        assert_eq!(parsed.graph.timeline.direction, Some(Direction::TopDown));
+
+        let parsed = parse_mermaid("timeline LR\n  2020 : Launch").unwrap();
+        assert_eq!(parsed.graph.direction, Direction::LeftRight);
+        assert_eq!(parsed.graph.timeline.direction, Some(Direction::LeftRight));
     }
 
     #[test]

--- a/src/render.rs
+++ b/src/render.rs
@@ -3757,12 +3757,15 @@ fn render_timeline(
     // Events
     for (i, event) in layout.events.iter().enumerate() {
         let color = colors[i % colors.len()];
+        let vertical = layout.direction == crate::ir::Direction::TopDown;
         let center_x = event.x + event.width / 2.0;
-        let circle_x = if layout.direction == crate::ir::Direction::TopDown {
+        let circle_x = if vertical {
             layout.line_start_x
         } else {
             center_x
         };
+        let text_x = if vertical { event.x + 8.0 } else { center_x };
+        let text_anchor = if vertical { "start" } else { "middle" };
 
         // Circle on timeline
         svg.push_str(&format!(
@@ -3770,7 +3773,7 @@ fn render_timeline(
             circle_x, event.circle_y, theme.primary_color, theme.primary_border_color
         ));
 
-        if layout.direction == crate::ir::Direction::TopDown {
+        if vertical {
             svg.push_str(&format!(
                 "<line x1=\"{:.2}\" y1=\"{:.2}\" x2=\"{:.2}\" y2=\"{:.2}\" stroke=\"{}\" stroke-width=\"2\" stroke-dasharray=\"4,2\"/>",
                 circle_x + 8.0,
@@ -3798,13 +3801,13 @@ fn render_timeline(
 
         // Time label (bold, at top of box)
         svg.push_str(&text_block_svg_with_font_size_weight(
-            center_x,
+            text_x,
             event.y + 20.0,
             &event.time,
             theme,
             config,
             theme.font_size,
-            "middle",
+            text_anchor,
             Some(theme.primary_text_color.as_str()),
             Some("bold"),
             true,
@@ -3819,13 +3822,13 @@ fn render_timeline(
         let event_line_height = event_font_size * config.label_line_height;
         for evt in &event.events {
             svg.push_str(&text_block_svg_with_font_size(
-                center_x,
+                text_x,
                 text_y,
                 evt,
                 theme,
                 config,
                 event_font_size,
-                "middle",
+                text_anchor,
                 Some(theme.primary_text_color.as_str()),
                 true,
             ));

--- a/src/render.rs
+++ b/src/render.rs
@@ -3742,7 +3742,11 @@ fn render_timeline(
     // Main timeline line
     svg.push_str(&format!(
         "<line x1=\"{:.2}\" y1=\"{:.2}\" x2=\"{:.2}\" y2=\"{:.2}\" stroke=\"{}\" stroke-width=\"3\"/>",
-        layout.line_start_x, layout.line_y, layout.line_end_x, layout.line_y, theme.primary_border_color
+        layout.line_start_x,
+        layout.line_start_y,
+        layout.line_end_x,
+        layout.line_end_y,
+        theme.primary_border_color
     ));
 
     // Colors for events
@@ -3754,18 +3758,37 @@ fn render_timeline(
     for (i, event) in layout.events.iter().enumerate() {
         let color = colors[i % colors.len()];
         let center_x = event.x + event.width / 2.0;
+        let circle_x = if layout.direction == crate::ir::Direction::TopDown {
+            layout.line_start_x
+        } else {
+            center_x
+        };
 
         // Circle on timeline
         svg.push_str(&format!(
             "<circle cx=\"{:.2}\" cy=\"{:.2}\" r=\"8\" fill=\"{}\" stroke=\"{}\" stroke-width=\"2\"/>",
-            center_x, event.circle_y, theme.primary_color, theme.primary_border_color
+            circle_x, event.circle_y, theme.primary_color, theme.primary_border_color
         ));
 
-        // Vertical connector line
-        svg.push_str(&format!(
-            "<line x1=\"{:.2}\" y1=\"{:.2}\" x2=\"{:.2}\" y2=\"{:.2}\" stroke=\"{}\" stroke-width=\"2\" stroke-dasharray=\"4,2\"/>",
-            center_x, event.circle_y + 8.0, center_x, event.y, theme.primary_border_color
-        ));
+        if layout.direction == crate::ir::Direction::TopDown {
+            svg.push_str(&format!(
+                "<line x1=\"{:.2}\" y1=\"{:.2}\" x2=\"{:.2}\" y2=\"{:.2}\" stroke=\"{}\" stroke-width=\"2\" stroke-dasharray=\"4,2\"/>",
+                circle_x + 8.0,
+                event.circle_y,
+                event.x,
+                event.circle_y,
+                theme.primary_border_color
+            ));
+        } else {
+            svg.push_str(&format!(
+                "<line x1=\"{:.2}\" y1=\"{:.2}\" x2=\"{:.2}\" y2=\"{:.2}\" stroke=\"{}\" stroke-width=\"2\" stroke-dasharray=\"4,2\"/>",
+                circle_x,
+                event.circle_y + 8.0,
+                circle_x,
+                event.y,
+                theme.primary_border_color
+            ));
+        }
 
         // Event box
         svg.push_str(&format!(

--- a/src/render.rs
+++ b/src/render.rs
@@ -3774,23 +3774,39 @@ fn render_timeline(
         ));
 
         // Time label (bold, at top of box)
-        svg.push_str(&format!(
-            "<text x=\"{:.2}\" y=\"{:.2}\" text-anchor=\"middle\" font-family=\"{}\" font-size=\"{:.1}\" font-weight=\"bold\" fill=\"{}\">{}</text>",
-            center_x, event.y + 20.0,
-            normalize_font_family(&theme.font_family), theme.font_size,
-            theme.primary_text_color, escape_xml(&event.time.lines.join(" "))
+        svg.push_str(&text_block_svg_with_font_size_weight(
+            center_x,
+            event.y + 20.0,
+            &event.time,
+            theme,
+            config,
+            theme.font_size,
+            "middle",
+            Some(theme.primary_text_color.as_str()),
+            Some("bold"),
+            true,
         ));
 
         // Event descriptions
-        let mut y_offset = 40.0;
+        let time_extra = event.time.lines.len().saturating_sub(1) as f32
+            * theme.font_size
+            * config.label_line_height;
+        let mut text_y = event.y + 40.0 + time_extra;
+        let event_font_size = theme.font_size * 0.9;
+        let event_line_height = event_font_size * config.label_line_height;
         for evt in &event.events {
-            svg.push_str(&format!(
-                "<text x=\"{:.2}\" y=\"{:.2}\" text-anchor=\"middle\" font-family=\"{}\" font-size=\"{:.1}\" fill=\"{}\">{}</text>",
-                center_x, event.y + y_offset,
-                normalize_font_family(&theme.font_family), theme.font_size * 0.9,
-                theme.primary_text_color, escape_xml(&evt.lines.join(" "))
+            svg.push_str(&text_block_svg_with_font_size(
+                center_x,
+                text_y,
+                evt,
+                theme,
+                config,
+                event_font_size,
+                "middle",
+                Some(theme.primary_text_color.as_str()),
+                true,
             ));
-            y_offset += theme.font_size * 1.2;
+            text_y += evt.lines.len() as f32 * event_line_height;
         }
     }
 

--- a/tests/layout_suite.rs
+++ b/tests/layout_suite.rs
@@ -502,6 +502,36 @@ fn timeline_direction_headers_and_config_default() {
 }
 
 #[test]
+fn timeline_vertical_cards_adapt_width_and_height() {
+    let input = r#"timeline TD
+  Short : A
+  Long : This vertical card should expand beyond the minimum width while remaining capped by the maximum width even with multiple words and wrap if needed
+"#;
+    let parsed = parse_mermaid(input).unwrap();
+    let theme = Theme::modern();
+    let config = LayoutConfig::default();
+    let layout = compute_layout(&parsed.graph, &theme, &config);
+    let DiagramData::Timeline(timeline) = &layout.diagram else {
+        panic!("expected timeline layout");
+    };
+
+    let short = &timeline.events[0];
+    let long = &timeline.events[1];
+    assert_eq!(short.width, 120.0);
+    assert!(
+        short.height < 80.0,
+        "short card height was {}",
+        short.height
+    );
+    assert!(long.width > 120.0, "long card width was {}", long.width);
+    assert!(long.width <= 360.0, "long card width was {}", long.width);
+    assert!(long.height > 80.0, "long card height was {}", long.height);
+
+    let svg = render_svg(&layout, &theme, &config);
+    assert!(svg.contains("text-anchor=\"start\""));
+}
+
+#[test]
 fn pie_outside_labels_do_not_intrude_into_right_legend() {
     let input = r#"pie
 "Dogs" : 386

--- a/tests/layout_suite.rs
+++ b/tests/layout_suite.rs
@@ -1,7 +1,9 @@
 use std::path::Path;
 
 use mermaid_rs_renderer::layout::{DiagramData, validate_layout_invariants};
-use mermaid_rs_renderer::{Layout, LayoutConfig, Theme, compute_layout, parse_mermaid, render_svg};
+use mermaid_rs_renderer::{
+    Direction, Layout, LayoutConfig, Theme, compute_layout, parse_mermaid, render_svg,
+};
 
 fn assert_valid_svg(svg: &str, fixture: &str) {
     assert!(svg.contains("<svg"), "{fixture}: missing <svg tag");
@@ -457,6 +459,46 @@ fn timeline_event_descriptions_wrap_inside_cards() {
     let svg = render_svg(&layout, &theme, &config);
     assert!(!svg.contains(">Electricity, Internal combustion engine, Mass production</text>"));
     assert!(svg.contains(">power</tspan>"));
+}
+
+#[test]
+fn timeline_direction_headers_and_config_default() {
+    let input = "timeline TD\n  title History\n  2020 : Launch\n  2021 : Growth\n  2022 : Scale";
+    let parsed = parse_mermaid(input).unwrap();
+    let theme = Theme::modern();
+    let config = LayoutConfig::default();
+    let layout = compute_layout(&parsed.graph, &theme, &config);
+    let DiagramData::Timeline(timeline) = &layout.diagram else {
+        panic!("expected timeline layout");
+    };
+    assert_eq!(timeline.direction, Direction::TopDown);
+    assert_eq!(timeline.line_start_x, timeline.line_end_x);
+    assert!(timeline.line_end_y > timeline.line_start_y);
+    assert!(timeline.height > timeline.width);
+    assert!(timeline.events.windows(2).all(|pair| pair[0].y < pair[1].y));
+
+    let input = "timeline\n  2020 : Launch\n  2021 : Growth\n  2022 : Scale";
+    let parsed = parse_mermaid(input).unwrap();
+    assert_eq!(parsed.graph.timeline.direction, None);
+    let mut config = LayoutConfig::default();
+    config.timeline.direction = "TD".to_string();
+    let layout = compute_layout(&parsed.graph, &theme, &config);
+    let DiagramData::Timeline(timeline) = &layout.diagram else {
+        panic!("expected timeline layout");
+    };
+    assert_eq!(timeline.direction, Direction::TopDown);
+    assert!(timeline.height > timeline.width);
+
+    let input = "timeline LR\n  2020 : Launch\n  2021 : Growth\n  2022 : Scale";
+    let parsed = parse_mermaid(input).unwrap();
+    let layout = compute_layout(&parsed.graph, &theme, &config);
+    let DiagramData::Timeline(timeline) = &layout.diagram else {
+        panic!("expected timeline layout");
+    };
+    assert_eq!(timeline.direction, Direction::LeftRight);
+    assert_eq!(timeline.line_start_y, timeline.line_end_y);
+    assert!(timeline.line_end_x > timeline.line_start_x);
+    assert!(timeline.width > timeline.height);
 }
 
 #[test]

--- a/tests/layout_suite.rs
+++ b/tests/layout_suite.rs
@@ -412,6 +412,54 @@ fn render_all_fixtures() {
 }
 
 #[test]
+fn timeline_event_descriptions_wrap_inside_cards() {
+    let input = r#"timeline
+    title Timeline of Industrial Revolution
+    Industry 1.0 : Machinery, Water power, Steam <br>power
+    Industry 2.0 : Electricity, Internal combustion engine, Mass production
+"#;
+    let parsed = parse_mermaid(input).unwrap();
+    let theme = Theme::modern();
+    let config = LayoutConfig::default();
+    let layout = compute_layout(&parsed.graph, &theme, &config);
+    let DiagramData::Timeline(timeline) = &layout.diagram else {
+        panic!("expected timeline layout");
+    };
+
+    let wrapped = timeline
+        .events
+        .iter()
+        .find(|event| event.time.lines.join(" ") == "Industry 2.0")
+        .expect("expected Industry 2.0 event");
+    assert!(
+        wrapped.events[0].lines.len() > 1,
+        "expected long description to wrap: {:?}",
+        wrapped.events[0].lines
+    );
+    assert!(
+        wrapped.height > 80.0,
+        "event card height should expand for wrapped descriptions"
+    );
+
+    let explicit_break = timeline
+        .events
+        .iter()
+        .find(|event| event.time.lines.join(" ") == "Industry 1.0")
+        .expect("expected Industry 1.0 event");
+    assert!(
+        explicit_break.events[0]
+            .lines
+            .iter()
+            .any(|line| line == "power"),
+        "expected explicit <br> to survive as a separate rendered line"
+    );
+
+    let svg = render_svg(&layout, &theme, &config);
+    assert!(!svg.contains(">Electricity, Internal combustion engine, Mass production</text>"));
+    assert!(svg.contains(">power</tspan>"));
+}
+
+#[test]
 fn pie_outside_labels_do_not_intrude_into_right_legend() {
     let input = r#"pie
 "Dogs" : 386


### PR DESCRIPTION
## Summary
- Closes #86.
- Parse Mermaid-compatible `timeline TD` and `timeline LR` headers, with explicit headers taking precedence.
- Add `timeline.defaultDirection` config support for bare `timeline` diagrams.
- Render `TD` timelines vertically with left-aligned event text and adaptive 120–360px event card widths while preserving the horizontal `LR` behavior and the wrapping changes from #82.

## Visual comparison

Generated from `timeline.mmd` with the timeline text-wrapping fix from #82 included.

| Horizontal timeline (current `LR` behavior) | Vertical timeline (new `TD` behavior) |
| --- | --- |
| <img width="1078" height="441" alt="image" src="https://github.com/user-attachments/assets/2473264a-8b42-43b1-a1e2-32382cbe083a" /> | <img width="462" height="641" alt="image" src="https://github.com/user-attachments/assets/0a0be005-68c2-42ca-8e88-621516e3ccdc" /> |

## Config default direction

Bare `timeline` diagrams default to horizontal `LR`. To make bare timeline diagrams render vertically by default, set `timeline.defaultDirection` in the config file:

```json
{
  "timeline": {
    "defaultDirection": "TD"
  }
}
```

Explicit diagram headers still take precedence over the config default:

```.mmd
timeline LR
  2024 : Explicitly horizontal
```

```.mmd
timeline TD
  2024 : Explicitly vertical
```

## Dependency
- This branch is stacked on #82 to avoid conflicts with the open timeline text-wrapping PR. The feature-only diff is `origin/pr-82...feature/timeline-direction`.

## Test plan
- [x] `cargo fmt -- --check`
- [x] `cargo test timeline --all-targets --all-features`
- [x] `cargo test merge_init_config_updates_timeline_default_direction`
- [x] `cargo test --test layout_suite`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo check --locked --no-default-features`
- [x] `cargo check --locked --no-default-features --features cli`
- [x] `cargo check --locked --no-default-features --features png`
- [ ] `cargo test --all-targets --all-features` (existing unrelated failure: `layout::tests::dense_flowchart_keeps_mid_span_edge_reasonably_direct` in `src/layout/mod.rs:1898`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/1jehuang/codesmith/mermaid-rs-renderer/pr/87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->