### PR TITLE
Fix font family case matching

### DIFF
--- a/src/text_metrics.rs
+++ b/src/text_metrics.rs
@@ -8,6 +8,7 @@ use std::sync::Mutex;
 use ttf_parser::{Face, GlyphId};
 
 static TEXT_MEASURER: Lazy<Mutex<TextMeasurer>> = Lazy::new(|| Mutex::new(TextMeasurer::new()));
+const FONT_CACHE_VERSION: &str = "v2-font-family-case";
 
 pub fn measure_text_width(text: &str, font_size: f32, font_family: &str) -> Option<f32> {
     if text.is_empty() || font_size <= 0.0 {
@@ -65,6 +66,10 @@ impl TextMeasurer {
         if let Some(face) = load_cached_face(&family_key) {
             return Some(face);
         }
+        if !self.loaded_system_fonts {
+            self.db.load_system_fonts();
+            self.loaded_system_fonts = true;
+        }
         #[derive(Clone, Copy)]
         enum FamilyToken {
             Generic(fontdb::Family<'static>),
@@ -91,7 +96,9 @@ impl TextMeasurer {
                 "ui-monospace" => order.push(FamilyToken::Generic(Family::Monospace)),
                 _ => {
                     let idx = names.len();
-                    names.push(raw.to_string());
+                    names.push(
+                        canonical_family_name(&self.db, raw).unwrap_or_else(|| raw.to_string()),
+                    );
                     order.push(FamilyToken::Name(idx));
                 }
             }
@@ -106,11 +113,6 @@ impl TextMeasurer {
                 FamilyToken::Generic(family) => families.push(family),
                 FamilyToken::Name(idx) => families.push(Family::Name(names[idx].as_str())),
             }
-        }
-
-        if !self.loaded_system_fonts {
-            self.db.load_system_fonts();
-            self.loaded_system_fonts = true;
         }
 
         let query = Query {
@@ -229,13 +231,21 @@ impl FontFace {
     }
 }
 
+fn canonical_family_name(db: &Database, raw: &str) -> Option<String> {
+    db.faces()
+        .flat_map(|face| face.families.iter().map(|(family, _)| family))
+        .find(|family| family.eq_ignore_ascii_case(raw))
+        .cloned()
+}
+
 fn normalize_family_key(font_family: &str) -> String {
     let trimmed = font_family.trim();
-    if trimmed.is_empty() {
-        "sans-serif".to_string()
+    let family = if trimmed.is_empty() {
+        "sans-serif"
     } else {
-        trimmed.to_string()
-    }
+        trimmed
+    };
+    format!("{FONT_CACHE_VERSION}:{family}")
 }
 
 fn cache_paths(family_key: &str) -> Option<(PathBuf, PathBuf)> {
@@ -261,4 +271,44 @@ fn load_cached_face(family_key: &str) -> Option<FontFace> {
     let face = Face::parse(&bytes, index).ok()?;
     let units_per_em = face.units_per_em().max(1);
     Some(FontFace::new(bytes, index, units_per_em))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fontdb::{FaceInfo, ID, Language, Source};
+    use std::sync::Arc;
+
+    fn push_family(db: &mut Database, family: &str) {
+        db.push_face_info(FaceInfo {
+            id: ID::dummy(),
+            source: Source::Binary(Arc::new(Vec::<u8>::new())),
+            index: 0,
+            families: vec![(family.to_string(), Language::English_UnitedStates)],
+            post_script_name: family.replace(' ', ""),
+            style: Style::Normal,
+            weight: Weight::NORMAL,
+            stretch: Stretch::Normal,
+            monospaced: false,
+        });
+    }
+
+    #[test]
+    fn canonical_family_name_matches_case_insensitively() {
+        let mut db = Database::new();
+        push_family(&mut db, "Trebuchet MS");
+
+        assert_eq!(
+            canonical_family_name(&db, "trebuchet ms").as_deref(),
+            Some("Trebuchet MS")
+        );
+    }
+
+    #[test]
+    fn normalize_family_key_uses_versioned_cache_namespace() {
+        assert_eq!(
+            normalize_family_key("trebuchet ms"),
+            "v2-font-family-case:trebuchet ms"
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- Closes #88.
- Resolve explicit CSS/SVG `font-family` names case-insensitively before querying `fontdb`, so default stacks like `trebuchet ms, verdana, arial, ...` can match canonical system families such as `Trebuchet MS`.
- Move cached font files into a new `v2-font-family-case` namespace.

## Cache namespace note
The cache key includes a version salt because older builds may already have cached the wrong font for the same raw family stack. For example, the lowercase Mermaid default stack could fall through to `Apple Color Emoji` and write that face under the old hash. Without a new cache namespace, the fixed lookup could continue loading that stale cached face and appear not to work until users manually clear `~/.cache/mmdr/font-cache`.

## Test plan
- [x] `cargo fmt -- --check`
- [x] `cargo test text_metrics`
- [x] `cargo test --test layout_suite`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo check --locked --no-default-features`
- [x] `cargo check --locked --no-default-features --features cli`
- [x] `cargo check --locked --no-default-features --features png`
- [x] `cargo test --lib` (existing unrelated failure: `layout::tests::dense_flowchart_keeps_mid_span_edge_reasonably_direct` in `src/layout/mod.rs:1898`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/1jehuang/codesmith/mermaid-rs-renderer/pr/89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->