### PR TITLE
config: support fastTextMetrics in JSON config

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1455,6 +1455,7 @@ struct ConfigFile {
     theme: Option<String>,
     theme_variables: Option<ThemeVariables>,
     preferred_aspect_ratio: Option<NumberOrString>,
+    fast_text_metrics: Option<bool>,
     flowchart: Option<FlowchartConfig>,
     pie: Option<PieConfigFile>,
     requirement: Option<RequirementConfigFile>,
@@ -1725,6 +1726,10 @@ pub fn load_config(path: Option<&Path>) -> anyhow::Result<Config> {
         .filter(|ratio| ratio.is_finite() && *ratio > 0.0)
     {
         config.layout.preferred_aspect_ratio = Some(ratio);
+    }
+
+    if let Some(fast_text) = parsed.fast_text_metrics {
+        config.layout.fast_text_metrics = fast_text;
     }
 
     if let Some(flow) = parsed.flowchart {
@@ -2809,5 +2814,43 @@ mod tests {
         );
         assert_eq!(mindmap.root_fill, Some("#444444".to_string()));
         assert_eq!(mindmap.root_text, Some("#555555".to_string()));
+    }
+
+    #[test]
+    fn fast_text_metrics_parses_from_camel_case() {
+        let parsed: ConfigFile =
+            serde_json::from_str(r##"{"fastTextMetrics": true}"##).expect("should parse");
+        assert_eq!(parsed.fast_text_metrics, Some(true));
+    }
+
+    #[test]
+    fn fast_text_metrics_applied_by_load_config() {
+        let mut path = std::env::temp_dir();
+        path.push(format!(
+            "mermaid_rs_fast_text_metrics_{}.json",
+            std::process::id()
+        ));
+        std::fs::write(&path, r##"{"fastTextMetrics": true}"##)
+            .expect("should write temp config");
+
+        let config = load_config(Some(&path)).expect("should load config");
+        assert!(config.layout.fast_text_metrics);
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn fast_text_metrics_default_is_false_when_absent() {
+        let mut path = std::env::temp_dir();
+        path.push(format!(
+            "mermaid_rs_fast_text_metrics_absent_{}.json",
+            std::process::id()
+        ));
+        std::fs::write(&path, "{}").expect("should write temp config");
+
+        let config = load_config(Some(&path)).expect("should load config");
+        assert!(!config.layout.fast_text_metrics);
+
+        let _ = std::fs::remove_file(&path);
     }
 }


### PR DESCRIPTION
## Problem

`LayoutConfig.fast_text_metrics` can currently only be toggled via the CLI's `--fastText` flag. Library users / non-CLI consumers who load settings through `config.json` have no way to enable the fast text metrics path, even though every other layout knob (e.g. `preferredAspectRatio`, the `flowchart.*` block) is available there.

## Fix

Add an optional `fastTextMetrics` boolean to the top-level `ConfigFile` struct and apply it to `config.layout.fast_text_metrics` inside `load_config()`, mirroring the existing `preferredAspectRatio` pattern. The CLI flag continues to work unchanged.

## Example

```json
{
  "fastTextMetrics": true,
  "preferredAspectRatio": 1.6
}
```

## Tests

Three new unit tests in `src/config.rs`:
- `fastTextMetrics: true` deserializes into `ConfigFile`.
- `load_config()` applies it to `config.layout.fast_text_metrics`.
- Absent field leaves `fast_text_metrics` at its `false` default.

`cargo check --no-default-features` and `cargo test --no-default-features` pass (one unrelated pre-existing failure in `layout::tests::dense_flowchart_keeps_mid_span_edge_reasonably_direct` reproduces on master without these changes).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/1jehuang/codesmith/mermaid-rs-renderer/pr/90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->