### PR TITLE
Improve CJK and emoji fallback text widths

### DIFF
--- a/src/layout/text.rs
+++ b/src/layout/text.rs
@@ -131,8 +131,49 @@ pub(super) fn char_width_factor(ch: char) -> f32 {
         '8' => 0.611,
         '9' => 0.595,
         '@' | '#' | '%' | '&' => 0.946,
+        _ if is_emoji_modifier_char(ch) => 0.0,
+        _ if is_cjk_wide_char(ch) || is_emoji_wide_char(ch) => 1.0,
         _ => 0.568,
     }
+}
+
+fn is_cjk_wide_char(ch: char) -> bool {
+    matches!(
+        ch,
+        '\u{1100}'..='\u{11ff}'
+            | '\u{2e80}'..='\u{a4cf}'
+            | '\u{a960}'..='\u{a97f}'
+            | '\u{ac00}'..='\u{d7ff}'
+            | '\u{f900}'..='\u{faff}'
+            | '\u{fe10}'..='\u{fe1f}'
+            | '\u{fe30}'..='\u{fe4f}'
+            | '\u{ff01}'..='\u{ff60}'
+            | '\u{ffe0}'..='\u{ffe6}'
+            | '\u{20000}'..='\u{2fa1f}'
+            | '\u{30000}'..='\u{323af}'
+    )
+}
+
+fn is_emoji_wide_char(ch: char) -> bool {
+    matches!(
+        ch,
+        '\u{2600}'..='\u{27bf}' | '\u{1f000}'..='\u{1faff}'
+    )
+}
+
+fn is_emoji_modifier_char(ch: char) -> bool {
+    matches!(
+        ch,
+        '\u{200d}' | '\u{20e3}' | '\u{fe00}'..='\u{fe0f}' | '\u{1f3fb}'..='\u{1f3ff}'
+    )
+}
+
+fn is_regional_indicator(ch: char) -> bool {
+    matches!(ch, '\u{1f1e6}'..='\u{1f1ff}')
+}
+
+fn is_keycap_starter(ch: char) -> bool {
+    ch.is_ascii_digit() || matches!(ch, '#' | '*')
 }
 
 pub(super) fn split_lines(text: &str) -> Vec<String> {
@@ -408,7 +449,54 @@ pub(super) fn text_width(text: &str, font_size: f32, font_family: &str, fast_met
 }
 
 fn fallback_text_width(text: &str, font_size: f32) -> f32 {
-    text.chars().map(char_width_factor).sum::<f32>() * font_size
+    let chars: Vec<char> = text.chars().collect();
+    let mut width = 0.0;
+    let mut idx = 0usize;
+    while idx < chars.len() {
+        let ch = chars[idx];
+        if is_keycap_starter(ch) {
+            let next = idx + 1;
+            let keycap = if chars.get(next) == Some(&'\u{fe0f}') {
+                next + 1
+            } else {
+                next
+            };
+            if chars.get(keycap) == Some(&'\u{20e3}') {
+                width += 1.0;
+                idx = keycap + 1;
+                continue;
+            }
+        }
+        if is_regional_indicator(ch)
+            && chars
+                .get(idx + 1)
+                .copied()
+                .is_some_and(is_regional_indicator)
+        {
+            width += 1.0;
+            idx += 2;
+            continue;
+        }
+        if is_emoji_wide_char(ch) {
+            width += 1.0;
+            idx += 1;
+            while idx < chars.len() {
+                if chars[idx] == '\u{200d}'
+                    && chars.get(idx + 1).copied().is_some_and(is_emoji_wide_char)
+                {
+                    idx += 2;
+                } else if is_emoji_modifier_char(chars[idx]) {
+                    idx += 1;
+                } else {
+                    break;
+                }
+            }
+            continue;
+        }
+        width += char_width_factor(ch);
+        idx += 1;
+    }
+    width * font_size
 }
 
 fn average_char_width(font_family: &str, font_size: f32, fast_metrics: bool) -> f32 {
@@ -448,6 +536,43 @@ mod tests {
     fn char_width_factor_returns_positive_values() {
         for ch in ['a', 'Z', ' ', '0', '@', '\u{4e2d}'] {
             assert!(char_width_factor(ch) > 0.0, "char {:?} has zero width", ch);
+        }
+    }
+
+    #[test]
+    fn char_width_factor_treats_cjk_as_wide() {
+        for ch in ['中', 'あ', '한', '。', 'Ａ'] {
+            assert_eq!(char_width_factor(ch), 1.0, "char {:?} should be wide", ch);
+        }
+    }
+
+    #[test]
+    fn char_width_factor_treats_emoji_as_wide() {
+        for ch in ['🙂', '🚀', '☀', '❤'] {
+            assert_eq!(char_width_factor(ch), 1.0, "char {:?} should be wide", ch);
+        }
+    }
+
+    #[test]
+    fn char_width_factor_treats_emoji_modifiers_as_zero_width() {
+        for ch in ['🏽', '\u{fe0f}', '\u{200d}', '\u{20e3}'] {
+            assert_eq!(
+                char_width_factor(ch),
+                0.0,
+                "char {:?} should be zero width",
+                ch
+            );
+        }
+    }
+
+    #[test]
+    fn fallback_text_width_counts_emoji_sequences_as_single_wide_glyphs() {
+        for text in ["👍🏽", "👨‍👩‍👧‍👦", "🇨🇳", "1️⃣"] {
+            assert_eq!(
+                fallback_text_width(text, 16.0),
+                16.0,
+                "{text} should be 1em"
+            );
         }
     }
 

--- a/src/layout/text.rs
+++ b/src/layout/text.rs
@@ -1,6 +1,7 @@
 use crate::config::LayoutConfig;
 use crate::text_metrics;
 use crate::theme::Theme;
+use crate::unicode_width::{Cluster, consume_cluster, is_cjk_wide_char};
 
 use super::TextBlock;
 
@@ -131,49 +132,9 @@ pub(super) fn char_width_factor(ch: char) -> f32 {
         '8' => 0.611,
         '9' => 0.595,
         '@' | '#' | '%' | '&' => 0.946,
-        _ if is_emoji_modifier_char(ch) => 0.0,
-        _ if is_cjk_wide_char(ch) || is_emoji_wide_char(ch) => 1.0,
+        _ if is_cjk_wide_char(ch) => 1.0,
         _ => 0.568,
     }
-}
-
-fn is_cjk_wide_char(ch: char) -> bool {
-    matches!(
-        ch,
-        '\u{1100}'..='\u{11ff}'
-            | '\u{2e80}'..='\u{a4cf}'
-            | '\u{a960}'..='\u{a97f}'
-            | '\u{ac00}'..='\u{d7ff}'
-            | '\u{f900}'..='\u{faff}'
-            | '\u{fe10}'..='\u{fe1f}'
-            | '\u{fe30}'..='\u{fe4f}'
-            | '\u{ff01}'..='\u{ff60}'
-            | '\u{ffe0}'..='\u{ffe6}'
-            | '\u{20000}'..='\u{2fa1f}'
-            | '\u{30000}'..='\u{323af}'
-    )
-}
-
-fn is_emoji_wide_char(ch: char) -> bool {
-    matches!(
-        ch,
-        '\u{2600}'..='\u{27bf}' | '\u{1f000}'..='\u{1faff}'
-    )
-}
-
-fn is_emoji_modifier_char(ch: char) -> bool {
-    matches!(
-        ch,
-        '\u{200d}' | '\u{20e3}' | '\u{fe00}'..='\u{fe0f}' | '\u{1f3fb}'..='\u{1f3ff}'
-    )
-}
-
-fn is_regional_indicator(ch: char) -> bool {
-    matches!(ch, '\u{1f1e6}'..='\u{1f1ff}')
-}
-
-fn is_keycap_starter(ch: char) -> bool {
-    ch.is_ascii_digit() || matches!(ch, '#' | '*')
 }
 
 pub(super) fn split_lines(text: &str) -> Vec<String> {
@@ -453,47 +414,15 @@ fn fallback_text_width(text: &str, font_size: f32) -> f32 {
     let mut width = 0.0;
     let mut idx = 0usize;
     while idx < chars.len() {
-        let ch = chars[idx];
-        if is_keycap_starter(ch) {
-            let next = idx + 1;
-            let keycap = if chars.get(next) == Some(&'\u{fe0f}') {
-                next + 1
-            } else {
-                next
+        if let Some((kind, new_idx)) = consume_cluster(&chars, idx) {
+            width += match kind {
+                Cluster::Wide => 1.0,
+                Cluster::ZeroWidth => 0.0,
             };
-            if chars.get(keycap) == Some(&'\u{20e3}') {
-                width += 1.0;
-                idx = keycap + 1;
-                continue;
-            }
-        }
-        if is_regional_indicator(ch)
-            && chars
-                .get(idx + 1)
-                .copied()
-                .is_some_and(is_regional_indicator)
-        {
-            width += 1.0;
-            idx += 2;
+            idx = new_idx;
             continue;
         }
-        if is_emoji_wide_char(ch) {
-            width += 1.0;
-            idx += 1;
-            while idx < chars.len() {
-                if chars[idx] == '\u{200d}'
-                    && chars.get(idx + 1).copied().is_some_and(is_emoji_wide_char)
-                {
-                    idx += 2;
-                } else if is_emoji_modifier_char(chars[idx]) {
-                    idx += 1;
-                } else {
-                    break;
-                }
-            }
-            continue;
-        }
-        width += char_width_factor(ch);
+        width += char_width_factor(chars[idx]);
         idx += 1;
     }
     width * font_size
@@ -547,20 +476,12 @@ mod tests {
     }
 
     #[test]
-    fn char_width_factor_treats_emoji_as_wide() {
-        for ch in ['🙂', '🚀', '☀', '❤'] {
-            assert_eq!(char_width_factor(ch), 1.0, "char {:?} should be wide", ch);
-        }
-    }
-
-    #[test]
-    fn char_width_factor_treats_emoji_modifiers_as_zero_width() {
-        for ch in ['🏽', '\u{fe0f}', '\u{200d}', '\u{20e3}'] {
+    fn fallback_text_width_treats_emoji_as_one_em() {
+        for text in ["🙂", "🚀", "☀", "❤"] {
             assert_eq!(
-                char_width_factor(ch),
-                0.0,
-                "char {:?} should be zero width",
-                ch
+                fallback_text_width(text, 16.0),
+                16.0,
+                "{text} should be 1em via fallback_text_width"
             );
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,6 +100,7 @@ pub mod parser;
 pub mod render;
 mod text_metrics;
 pub mod theme;
+pub(crate) mod unicode_width;
 pub mod validator;
 
 // Re-export commonly used types at crate root for ergonomic library usage

--- a/src/text_metrics.rs
+++ b/src/text_metrics.rs
@@ -7,6 +7,8 @@ use std::path::PathBuf;
 use std::sync::Mutex;
 use ttf_parser::{Face, GlyphId};
 
+use crate::unicode_width::{Cluster, consume_cluster, is_cjk_wide_char};
+
 static TEXT_MEASURER: Lazy<Mutex<TextMeasurer>> = Lazy::new(|| Mutex::new(TextMeasurer::new()));
 
 pub fn measure_text_width(text: &str, font_size: f32, font_family: &str) -> Option<f32> {
@@ -213,49 +215,12 @@ impl FontFace {
             // render these via system font fallback (e.g. PingFang on iOS)
             // at roughly 1em even when the loaded face has no glyph for
             // them — using 0.56em here under-measures CJK by ~44%.
-            if is_keycap_starter(ch) {
-                let next = idx + 1;
-                let keycap = if chars.get(next) == Some(&'\u{fe0f}') {
-                    next + 1
-                } else {
-                    next
+            if let Some((kind, new_idx)) = consume_cluster(&chars, idx) {
+                width += match kind {
+                    Cluster::Wide => font_size,
+                    Cluster::ZeroWidth => 0.0,
                 };
-                if chars.get(keycap) == Some(&'\u{20e3}') {
-                    width += font_size;
-                    idx = keycap + 1;
-                    continue;
-                }
-            }
-            if is_regional_indicator(ch)
-                && chars
-                    .get(idx + 1)
-                    .copied()
-                    .is_some_and(is_regional_indicator)
-            {
-                width += font_size;
-                idx += 2;
-                continue;
-            }
-            if is_emoji_wide_char(ch) {
-                width += font_size;
-                idx += 1;
-                while idx < chars.len() {
-                    if chars[idx] == '\u{200d}'
-                        && chars.get(idx + 1).copied().is_some_and(is_emoji_wide_char)
-                    {
-                        idx += 2;
-                    } else if is_emoji_modifier_char(chars[idx]) {
-                        idx += 1;
-                    } else {
-                        break;
-                    }
-                }
-                continue;
-            }
-            if is_emoji_modifier_char(ch) {
-                // ZWJ / variation selectors / skin-tone modifiers contribute
-                // no advance on their own.
-                idx += 1;
+                idx = new_idx;
                 continue;
             }
 
@@ -288,45 +253,6 @@ impl FontFace {
     }
 }
 
-fn is_cjk_wide_char(ch: char) -> bool {
-    matches!(
-        ch,
-        '\u{1100}'..='\u{11ff}'
-            | '\u{2e80}'..='\u{a4cf}'
-            | '\u{a960}'..='\u{a97f}'
-            | '\u{ac00}'..='\u{d7ff}'
-            | '\u{f900}'..='\u{faff}'
-            | '\u{fe10}'..='\u{fe1f}'
-            | '\u{fe30}'..='\u{fe4f}'
-            | '\u{ff01}'..='\u{ff60}'
-            | '\u{ffe0}'..='\u{ffe6}'
-            | '\u{20000}'..='\u{2fa1f}'
-            | '\u{30000}'..='\u{323af}'
-    )
-}
-
-fn is_emoji_wide_char(ch: char) -> bool {
-    matches!(
-        ch,
-        '\u{2600}'..='\u{27bf}' | '\u{1f000}'..='\u{1faff}'
-    )
-}
-
-fn is_emoji_modifier_char(ch: char) -> bool {
-    matches!(
-        ch,
-        '\u{200d}' | '\u{20e3}' | '\u{fe00}'..='\u{fe0f}' | '\u{1f3fb}'..='\u{1f3ff}'
-    )
-}
-
-fn is_regional_indicator(ch: char) -> bool {
-    matches!(ch, '\u{1f1e6}'..='\u{1f1ff}')
-}
-
-fn is_keycap_starter(ch: char) -> bool {
-    ch.is_ascii_digit() || matches!(ch, '#' | '*')
-}
-
 fn normalize_family_key(font_family: &str) -> String {
     let trimmed = font_family.trim();
     if trimmed.is_empty() {
@@ -354,37 +280,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn cjk_helper_recognises_common_ranges() {
-        for ch in ['中', '文', 'あ', 'カ', '한', '。', 'Ａ'] {
-            assert!(
-                is_cjk_wide_char(ch),
-                "char {:?} should be classified as CJK-wide",
-                ch
-            );
-        }
-    }
-
-    #[test]
-    fn cjk_helper_rejects_ascii_and_latin_extended() {
-        for ch in ['a', 'Z', '0', ' ', 'é', 'ß'] {
-            assert!(
-                !is_cjk_wide_char(ch),
-                "char {:?} should not be classified as CJK-wide",
-                ch
-            );
-        }
-    }
-
-    #[test]
-    fn emoji_helpers_classify_modifiers_and_wide() {
-        assert!(is_emoji_wide_char('\u{1f600}')); // grinning face
-        assert!(is_emoji_modifier_char('\u{200d}')); // ZWJ
-        assert!(is_emoji_modifier_char('\u{fe0f}')); // VS16
-        assert!(is_emoji_modifier_char('\u{1f3fb}')); // skin tone
-        assert!(is_regional_indicator('\u{1f1fa}')); // U
-        assert!(is_keycap_starter('1'));
-        assert!(is_keycap_starter('#'));
-        assert!(!is_keycap_starter('a'));
+    fn measure_empty_text_is_zero() {
+        assert_eq!(measure_text_width("", 16.0, "sans-serif"), Some(0.0));
     }
 }
 

--- a/src/text_metrics.rs
+++ b/src/text_metrics.rs
@@ -197,11 +197,68 @@ impl FontFace {
         let face = Face::parse(&self.data, self.index).ok()?;
         let scale = font_size / self.units_per_em as f32;
         let mut width = 0.0f32;
+        let chars: Vec<char> = text.chars().collect();
+        let mut idx = 0usize;
 
-        for ch in text.chars() {
+        while idx < chars.len() {
+            let ch = chars[idx];
             if ch == '\n' {
+                idx += 1;
                 continue;
             }
+
+            // Mirror fallback_text_width grapheme-cluster handling so both
+            // measurement paths agree on widths for CJK ideographs, kana,
+            // hangul, fullwidth chars, and emoji sequences. The OS will
+            // render these via system font fallback (e.g. PingFang on iOS)
+            // at roughly 1em even when the loaded face has no glyph for
+            // them — using 0.56em here under-measures CJK by ~44%.
+            if is_keycap_starter(ch) {
+                let next = idx + 1;
+                let keycap = if chars.get(next) == Some(&'\u{fe0f}') {
+                    next + 1
+                } else {
+                    next
+                };
+                if chars.get(keycap) == Some(&'\u{20e3}') {
+                    width += font_size;
+                    idx = keycap + 1;
+                    continue;
+                }
+            }
+            if is_regional_indicator(ch)
+                && chars
+                    .get(idx + 1)
+                    .copied()
+                    .is_some_and(is_regional_indicator)
+            {
+                width += font_size;
+                idx += 2;
+                continue;
+            }
+            if is_emoji_wide_char(ch) {
+                width += font_size;
+                idx += 1;
+                while idx < chars.len() {
+                    if chars[idx] == '\u{200d}'
+                        && chars.get(idx + 1).copied().is_some_and(is_emoji_wide_char)
+                    {
+                        idx += 2;
+                    } else if is_emoji_modifier_char(chars[idx]) {
+                        idx += 1;
+                    } else {
+                        break;
+                    }
+                }
+                continue;
+            }
+            if is_emoji_modifier_char(ch) {
+                // ZWJ / variation selectors / skin-tone modifiers contribute
+                // no advance on their own.
+                idx += 1;
+                continue;
+            }
+
             let glyph = if let Some(cached) = self.glyph_cache.get(&ch) {
                 *cached
             } else {
@@ -210,23 +267,64 @@ impl FontFace {
                 glyph
             };
 
-            let Some(glyph_id) = glyph else {
-                width += fallback;
-                continue;
-            };
-
-            let advance = if let Some(value) = self.advance_cache.get(&glyph_id) {
-                *value
+            if let Some(glyph_id) = glyph {
+                let advance = if let Some(value) = self.advance_cache.get(&glyph_id) {
+                    *value
+                } else {
+                    let value = face.glyph_hor_advance(GlyphId(glyph_id)).unwrap_or(0);
+                    self.advance_cache.insert(glyph_id, value);
+                    value
+                };
+                width += advance as f32 * scale;
+            } else if is_cjk_wide_char(ch) {
+                width += font_size;
             } else {
-                let value = face.glyph_hor_advance(GlyphId(glyph_id)).unwrap_or(0);
-                self.advance_cache.insert(glyph_id, value);
-                value
-            };
-            width += advance as f32 * scale;
+                width += fallback;
+            }
+            idx += 1;
         }
 
         Some(width.max(0.0))
     }
+}
+
+fn is_cjk_wide_char(ch: char) -> bool {
+    matches!(
+        ch,
+        '\u{1100}'..='\u{11ff}'
+            | '\u{2e80}'..='\u{a4cf}'
+            | '\u{a960}'..='\u{a97f}'
+            | '\u{ac00}'..='\u{d7ff}'
+            | '\u{f900}'..='\u{faff}'
+            | '\u{fe10}'..='\u{fe1f}'
+            | '\u{fe30}'..='\u{fe4f}'
+            | '\u{ff01}'..='\u{ff60}'
+            | '\u{ffe0}'..='\u{ffe6}'
+            | '\u{20000}'..='\u{2fa1f}'
+            | '\u{30000}'..='\u{323af}'
+    )
+}
+
+fn is_emoji_wide_char(ch: char) -> bool {
+    matches!(
+        ch,
+        '\u{2600}'..='\u{27bf}' | '\u{1f000}'..='\u{1faff}'
+    )
+}
+
+fn is_emoji_modifier_char(ch: char) -> bool {
+    matches!(
+        ch,
+        '\u{200d}' | '\u{20e3}' | '\u{fe00}'..='\u{fe0f}' | '\u{1f3fb}'..='\u{1f3ff}'
+    )
+}
+
+fn is_regional_indicator(ch: char) -> bool {
+    matches!(ch, '\u{1f1e6}'..='\u{1f1ff}')
+}
+
+fn is_keycap_starter(ch: char) -> bool {
+    ch.is_ascii_digit() || matches!(ch, '#' | '*')
 }
 
 fn normalize_family_key(font_family: &str) -> String {
@@ -249,6 +347,45 @@ fn cache_paths(family_key: &str) -> Option<(PathBuf, PathBuf)> {
     let font_path = dir.join(format!("{hash:x}.font"));
     let meta_path = dir.join(format!("{hash:x}.meta"));
     Some((font_path, meta_path))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cjk_helper_recognises_common_ranges() {
+        for ch in ['中', '文', 'あ', 'カ', '한', '。', 'Ａ'] {
+            assert!(
+                is_cjk_wide_char(ch),
+                "char {:?} should be classified as CJK-wide",
+                ch
+            );
+        }
+    }
+
+    #[test]
+    fn cjk_helper_rejects_ascii_and_latin_extended() {
+        for ch in ['a', 'Z', '0', ' ', 'é', 'ß'] {
+            assert!(
+                !is_cjk_wide_char(ch),
+                "char {:?} should not be classified as CJK-wide",
+                ch
+            );
+        }
+    }
+
+    #[test]
+    fn emoji_helpers_classify_modifiers_and_wide() {
+        assert!(is_emoji_wide_char('\u{1f600}')); // grinning face
+        assert!(is_emoji_modifier_char('\u{200d}')); // ZWJ
+        assert!(is_emoji_modifier_char('\u{fe0f}')); // VS16
+        assert!(is_emoji_modifier_char('\u{1f3fb}')); // skin tone
+        assert!(is_regional_indicator('\u{1f1fa}')); // U
+        assert!(is_keycap_starter('1'));
+        assert!(is_keycap_starter('#'));
+        assert!(!is_keycap_starter('a'));
+    }
 }
 
 fn load_cached_face(family_key: &str) -> Option<FontFace> {

--- a/src/unicode_width.rs
+++ b/src/unicode_width.rs
@@ -1,0 +1,187 @@
+//! Unicode width classification shared between layout-time fast metrics and
+//! glyph-advance text measurement.
+//!
+//! Both `layout::text::fallback_text_width` and
+//! `text_metrics::FontFace::measure_width` need to identify CJK ideographs,
+//! emoji, and emoji-cluster glue (ZWJ, variation selectors, skin-tone
+//! modifiers, regional-indicator flag pairs, keycap sequences) so they can
+//! agree on per-glyph widths. This module owns the codepoint tables and the
+//! cluster walker so the two paths cannot drift.
+//!
+//! CJK wide chars are intentionally NOT collapsed into [`consume_cluster`]:
+//! `measure_width` should still prefer the loaded font's real glyph advance
+//! for CJK and only fall back to 1 em when the glyph is missing, which
+//! requires keeping CJK as a per-char predicate.
+
+/// Classification of a multi-codepoint cluster recognised by
+/// [`consume_cluster`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Cluster {
+    /// Render at one em (e.g. an emoji, flag, keycap, or ZWJ family).
+    Wide,
+    /// Contributes no advance on its own (a stray ZWJ / VS / skin-tone
+    /// modifier that did not bind to a wide cluster).
+    ZeroWidth,
+}
+
+pub(crate) fn is_cjk_wide_char(ch: char) -> bool {
+    matches!(
+        ch,
+        '\u{1100}'..='\u{11ff}'
+            | '\u{2e80}'..='\u{a4cf}'
+            | '\u{a960}'..='\u{a97f}'
+            | '\u{ac00}'..='\u{d7ff}'
+            | '\u{f900}'..='\u{faff}'
+            | '\u{fe10}'..='\u{fe1f}'
+            | '\u{fe30}'..='\u{fe4f}'
+            | '\u{ff01}'..='\u{ff60}'
+            | '\u{ffe0}'..='\u{ffe6}'
+            | '\u{20000}'..='\u{2fa1f}'
+            | '\u{30000}'..='\u{323af}'
+    )
+}
+
+pub(crate) fn is_emoji_wide_char(ch: char) -> bool {
+    matches!(
+        ch,
+        '\u{2600}'..='\u{27bf}' | '\u{1f000}'..='\u{1faff}'
+    )
+}
+
+pub(crate) fn is_emoji_modifier_char(ch: char) -> bool {
+    matches!(
+        ch,
+        '\u{200d}' | '\u{20e3}' | '\u{fe00}'..='\u{fe0f}' | '\u{1f3fb}'..='\u{1f3ff}'
+    )
+}
+
+pub(crate) fn is_regional_indicator(ch: char) -> bool {
+    matches!(ch, '\u{1f1e6}'..='\u{1f1ff}')
+}
+
+pub(crate) fn is_keycap_starter(ch: char) -> bool {
+    ch.is_ascii_digit() || matches!(ch, '#' | '*')
+}
+
+/// Try to consume a multi-codepoint cluster starting at `chars[idx]` and
+/// return its width category along with the index just past the cluster.
+///
+/// Patterns are checked in priority order: keycap sequence, regional
+/// indicator pair (flag), emoji-wide cluster (with optional ZWJ joins and
+/// skin-tone modifiers), then standalone modifier. Returns `None` for plain
+/// characters (including CJK), letting the caller decide how to measure
+/// them.
+pub(crate) fn consume_cluster(chars: &[char], idx: usize) -> Option<(Cluster, usize)> {
+    let ch = *chars.get(idx)?;
+
+    // Keycap: `[0-9#*]` + optional VS16 + U+20E3.
+    if is_keycap_starter(ch) {
+        let next = idx + 1;
+        let keycap = if chars.get(next) == Some(&'\u{fe0f}') {
+            next + 1
+        } else {
+            next
+        };
+        if chars.get(keycap) == Some(&'\u{20e3}') {
+            return Some((Cluster::Wide, keycap + 1));
+        }
+    }
+
+    // Regional indicator pair → flag.
+    if is_regional_indicator(ch)
+        && chars
+            .get(idx + 1)
+            .copied()
+            .is_some_and(is_regional_indicator)
+    {
+        return Some((Cluster::Wide, idx + 2));
+    }
+
+    // Emoji wide base, optionally extended by ZWJ-joined emoji and/or
+    // trailing modifiers.
+    if is_emoji_wide_char(ch) {
+        let mut end = idx + 1;
+        while end < chars.len() {
+            if chars[end] == '\u{200d}'
+                && chars.get(end + 1).copied().is_some_and(is_emoji_wide_char)
+            {
+                end += 2;
+            } else if is_emoji_modifier_char(chars[end]) {
+                end += 1;
+            } else {
+                break;
+            }
+        }
+        return Some((Cluster::Wide, end));
+    }
+
+    // Standalone modifier that did not attach to a wide base above.
+    if is_emoji_modifier_char(ch) {
+        return Some((Cluster::ZeroWidth, idx + 1));
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn chars(s: &str) -> Vec<char> {
+        s.chars().collect()
+    }
+
+    #[test]
+    fn keycap_sequence_is_wide() {
+        let c = chars("1\u{fe0f}\u{20e3}");
+        assert_eq!(consume_cluster(&c, 0), Some((Cluster::Wide, c.len())));
+    }
+
+    #[test]
+    fn keycap_without_vs_is_wide() {
+        let c = chars("1\u{20e3}");
+        assert_eq!(consume_cluster(&c, 0), Some((Cluster::Wide, c.len())));
+    }
+
+    #[test]
+    fn regional_indicator_pair_is_wide() {
+        let c = chars("\u{1f1e8}\u{1f1f3}");
+        assert_eq!(consume_cluster(&c, 0), Some((Cluster::Wide, 2)));
+    }
+
+    #[test]
+    fn zwj_family_is_single_wide_cluster() {
+        let c = chars("\u{1f468}\u{200d}\u{1f469}\u{200d}\u{1f467}\u{200d}\u{1f466}");
+        assert_eq!(consume_cluster(&c, 0), Some((Cluster::Wide, c.len())));
+    }
+
+    #[test]
+    fn skin_tone_modifier_extends_cluster() {
+        let c = chars("\u{1f44d}\u{1f3fd}");
+        assert_eq!(consume_cluster(&c, 0), Some((Cluster::Wide, c.len())));
+    }
+
+    #[test]
+    fn standalone_zwj_is_zero_width() {
+        let c = chars("\u{200d}");
+        assert_eq!(consume_cluster(&c, 0), Some((Cluster::ZeroWidth, 1)));
+    }
+
+    #[test]
+    fn standalone_variation_selector_is_zero_width() {
+        let c = chars("\u{fe0f}");
+        assert_eq!(consume_cluster(&c, 0), Some((Cluster::ZeroWidth, 1)));
+    }
+
+    #[test]
+    fn ascii_returns_none() {
+        let c = chars("a");
+        assert_eq!(consume_cluster(&c, 0), None);
+    }
+
+    #[test]
+    fn cjk_returns_none() {
+        let c = chars("中");
+        assert_eq!(consume_cluster(&c, 0), None);
+    }
+}


### PR DESCRIPTION
## Summary
- Closes #91.
- Treat CJK wide/fullwidth characters and emoji as 1em in fallback text width estimates.
- Avoid counting emoji modifiers, variation selectors, keycap suffixes, regional indicator flag pairs, and ZWJ emoji sequences as extra glyph width.

## Test plan
- [x] `cargo fmt -- --check`
- [x] `cargo test layout::text::tests`
- [x] `cargo clippy --lib -- -D warnings`
- [ ] `cargo test --lib` — fails in this environment on `layout::tests::dense_flowchart_keeps_mid_span_edge_reasonably_direct` with `path=486.1, manhattan=168.1`; the failing ASCII flowchart routing assertion appears unrelated to this fallback text-width change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)