### PR TITLE
Add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,30 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is **mmdr** — a pure-Rust Mermaid diagram renderer CLI and library. No databases, Docker, or external services needed.
+
+### Build & test
+
+Standard commands per CI (see `.github/workflows/ci.yml`):
+
+- `cargo fmt -- --check` — formatting
+- `cargo clippy --all-targets --all-features -- -D warnings` — linting
+- `cargo test --all-targets --all-features` — full test suite (unit + CLI + invariant)
+- `cargo test --no-default-features --lib` — library-only tests without optional features
+- `cargo test --doc --all-features` — doc tests
+
+### Run the CLI
+
+```
+cargo run --all-features -- -i input.mmd -o output.svg
+```
+
+For PNG: add `-e png`. Stdin: use `-i -`. The `--timing` flag emits per-stage microsecond timings to stderr.
+
+### Gotchas
+
+- Rust edition 2024 requires **Rust 1.85+**. The update script runs `rustup update stable` to ensure this.
+- The `clippy.toml` sets `too-many-arguments-threshold = 10` and `type-complexity-threshold = 500`.
+- One invariant test (`all_repository_fixtures_satisfy_layout_invariants`) is known to fail on `master` — this is pre-existing and not caused by environment setup.
+- The `package.json` Node.js dependencies (`@mermaid-js/mermaid-cli`, `vega-cli`, `vega-lite`) are only for benchmarking scripts in `scripts/`; they are **not** needed for core development.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud-specific development instructions for future agents working on this codebase.

## What's included

- Build & test commands (referencing CI workflow)
- CLI usage notes
- Known gotchas:
  - Rust edition 2024 requires Rust 1.85+
  - Custom clippy thresholds
  - Pre-existing invariant test failure on master
  - Node.js deps are benchmark-only, not needed for core dev

## Environment verification

All core development workflows verified:

| Check | Result |
|-------|--------|
| `cargo fmt -- --check` | Pass |
| `cargo clippy --all-targets --all-features -- -D warnings` | Pass |
| `cargo test --all-targets --all-features` | 277/278 pass (1 pre-existing failure) |
| `cargo test --no-default-features --lib` | 263 pass |
| `cargo test --doc --all-features` | 5 pass |
| `mmdr` CLI (SVG + PNG rendering) | Working |

### Hello world demo

Rendered a flowchart diagram with the `mmdr` CLI:

[Flowchart hello world rendered by mmdr](https://cursor.com/agents/bc-19a153af-a48f-449c-b066-82531116d97c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fflowchart_hello_world.png)

Test results log:
[test_results.log](https://cursor.com/agents/bc-19a153af-a48f-449c-b066-82531116d97c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftest_results.log)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-19a153af-a48f-449c-b066-82531116d97c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-19a153af-a48f-449c-b066-82531116d97c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/1jehuang/codesmith/mermaid-rs-renderer/pr/93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->