### PR TITLE
Fix flowchart edge routing through non-endpoint nodes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,30 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is **mmdr** — a pure-Rust Mermaid diagram renderer CLI and library. No databases, Docker, or external services needed.
+
+### Build & test
+
+Standard commands per CI (see `.github/workflows/ci.yml`):
+
+- `cargo fmt -- --check` — formatting
+- `cargo clippy --all-targets --all-features -- -D warnings` — linting
+- `cargo test --all-targets --all-features` — full test suite (unit + CLI + invariant)
+- `cargo test --no-default-features --lib` — library-only tests without optional features
+- `cargo test --doc --all-features` — doc tests
+
+### Run the CLI
+
+```
+cargo run --all-features -- -i input.mmd -o output.svg
+```
+
+For PNG: add `-e png`. Stdin: use `-i -`. The `--timing` flag emits per-stage microsecond timings to stderr.
+
+### Gotchas
+
+- Rust edition 2024 requires **Rust 1.85+**. The update script runs `rustup update stable` to ensure this.
+- The `clippy.toml` sets `too-many-arguments-threshold = 10` and `type-complexity-threshold = 500`.
+- One invariant test (`all_repository_fixtures_satisfy_layout_invariants`) is known to fail on `master` — this is pre-existing and not caused by environment setup.
+- The `package.json` Node.js dependencies (`@mermaid-js/mermaid-cli`, `vega-cli`, `vega-lite`) are only for benchmarking scripts in `scripts/`; they are **not** needed for core development.

--- a/src/layout/flowchart/edge_pipeline.rs
+++ b/src/layout/flowchart/edge_pipeline.rs
@@ -879,6 +879,12 @@ pub(in crate::layout) fn build_routed_edges(ctx: RoutedEdgeBuildContext<'_>) -> 
             &mut routed_points,
             config,
         );
+        path_cleanup::detour_flowchart_paths_wider_clearance(
+            graph,
+            nodes,
+            &mut routed_points,
+            config,
+        );
     }
 
     route_labels::apply_label_dummy_anchors(

--- a/src/layout/flowchart/path_cleanup.rs
+++ b/src/layout/flowchart/path_cleanup.rs
@@ -478,6 +478,93 @@ pub(in crate::layout) fn detour_flowchart_paths_around_non_endpoint_nodes(
     }
 }
 
+pub(in crate::layout) fn detour_flowchart_paths_wider_clearance(
+    graph: &Graph,
+    nodes: &BTreeMap<String, NodeLayout>,
+    routed_points: &mut [Vec<(f32, f32)>],
+    config: &LayoutConfig,
+) {
+    let base_clearance = (config.node_spacing * 0.12).max(8.0);
+    for (idx, points) in routed_points.iter_mut().enumerate() {
+        let Some(edge) = graph.edges.get(idx) else {
+            continue;
+        };
+        let starting_hits = count_non_endpoint_node_hits(points, &edge.from, &edge.to, nodes);
+        if starting_hits == 0 {
+            continue;
+        }
+        for _ in 0..6 {
+            let Some((first_seg_idx, last_seg_idx, obstacle)) =
+                first_non_endpoint_node_hit(points, &edge.from, &edge.to, nodes)
+            else {
+                break;
+            };
+            let mut best: Option<Vec<(f32, f32)>> = None;
+            let mut best_cost = f32::INFINITY;
+            let mut best_hits = starting_hits;
+            for clearance_scale in [1.0_f32, 1.5, 2.5, 4.0] {
+                let clearance = base_clearance * clearance_scale;
+                for candidate in node_detour_candidates(
+                    points,
+                    first_seg_idx,
+                    last_seg_idx,
+                    &obstacle,
+                    clearance,
+                ) {
+                    let hits =
+                        count_non_endpoint_node_hits(&candidate, &edge.from, &edge.to, nodes);
+                    if hits > best_hits {
+                        continue;
+                    }
+                    let cost =
+                        path_length(&candidate) + path_bend_count(&candidate) as f32 * clearance;
+                    if hits < best_hits || cost < best_cost {
+                        best_cost = cost;
+                        best_hits = hits;
+                        best = Some(candidate);
+                    }
+                }
+                if best_hits == 0 {
+                    break;
+                }
+            }
+            let Some(candidate) = best else {
+                break;
+            };
+            *points = candidate;
+        }
+    }
+}
+
+fn count_non_endpoint_node_hits(
+    path: &[(f32, f32)],
+    from_id: &str,
+    to_id: &str,
+    nodes: &BTreeMap<String, NodeLayout>,
+) -> usize {
+    let mut count = 0;
+    for node in nodes.values() {
+        if node.id == from_id || node.id == to_id || node.hidden || node.anchor_subgraph.is_some() {
+            continue;
+        }
+        let obstacle = Obstacle {
+            id: node.id.clone(),
+            x: node.x,
+            y: node.y,
+            width: node.width,
+            height: node.height,
+            members: None,
+        };
+        if path
+            .windows(2)
+            .any(|seg| segment_intersects_rect(seg[0], seg[1], &obstacle))
+        {
+            count += 1;
+        }
+    }
+    count
+}
+
 fn bump_orthogonal_segment(
     points: &[(f32, f32)],
     seg_idx: usize,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes a pre-existing layout invariant violation where edge routes could intersect non-endpoint nodes in dense flowchart layouts. Specifically fixes `benches/fixtures/flowchart_grid_feedback.mmd` where edge N43→N22 incorrectly passed through node N33.

## Changes

### `src/layout/flowchart/path_cleanup.rs`
- Added `detour_flowchart_paths_wider_clearance` function: a final-pass edge detour that progressively widens clearance (1x → 1.5x → 2.5x → 4x base) to find valid routes around obstacles
- Added `count_non_endpoint_node_hits` helper to count intersected nodes for progressive improvement decisions
- The function only activates for edges that already have node intersections, preventing regressions

### `src/layout/flowchart/edge_pipeline.rs`
- Added call to `detour_flowchart_paths_wider_clearance` as the final cleanup step after the existing detour+simplify+detour pipeline

## Before / After / Reference

[Before/After/Reference comparison showing the fix](https://cursor.com/agents/bc-19a153af-a48f-449c-b066-82531116d97c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcomparison_screenshot.webp)

The fix routes edge N43→N22 around node N33 instead of through it, matching the reference behavior.

## Testing

- `cargo test --all-targets --all-features`: 277/278 pass (remaining 1 failure is the pre-existing `flowchart_opaque.mmd` label overlap, unrelated)
- `cargo clippy --all-targets --all-features -- -D warnings`: clean
- `cargo fmt -- --check`: clean
- No regressions: all previously-passing invariant fixtures continue to pass

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-19a153af-a48f-449c-b066-82531116d97c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-19a153af-a48f-449c-b066-82531116d97c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/1jehuang/codesmith/mermaid-rs-renderer/pr/94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->