### PR TITLE
fix: wasm32 compatibility via Instant mock (no cfg guards)

### DIFF
--- a/src/layout/flowchart/edge_pipeline.rs
+++ b/src/layout/flowchart/edge_pipeline.rs
@@ -1,6 +1,5 @@
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashMap};
-use std::time::Instant;
 
 use crate::config::LayoutConfig;
 use crate::ir::{DiagramKind, Graph};
@@ -217,7 +216,7 @@ pub(in crate::layout) fn build_routed_edges(ctx: RoutedEdgeBuildContext<'_>) -> 
     };
     let mut stage_metrics = stage_metrics;
 
-    let port_assignment_start = Instant::now();
+    let port_assignment_start = crate::time::Instant::now();
     let content_bounds = visible_node_bounds(nodes);
     let mut node_degrees: HashMap<String, usize> = HashMap::new();
     for edge in &graph.edges {
@@ -509,7 +508,7 @@ pub(in crate::layout) fn build_routed_edges(ctx: RoutedEdgeBuildContext<'_>) -> 
             .saturating_add(port_assignment_start.elapsed().as_micros());
     }
 
-    let edge_routing_start = Instant::now();
+    let edge_routing_start = crate::time::Instant::now();
     let lane_assignments = plan::plan_edge_lanes(graph, nodes, subgraphs, config);
     let lane_offsets = lane_assignments.effective_offsets(&edge_ports, graph.kind, config);
     let pair_counts = lane_assignments.pair_counts;

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -53,7 +53,6 @@ use crate::theme::{Theme, adjust_color, parse_color_to_hsl};
 use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashMap, HashSet};
-use std::time::Instant;
 
 // Label placement padding (resolved per diagram kind).
 // Minimum padding around the entire layout bounding box.
@@ -208,7 +207,7 @@ pub fn compute_layout_with_metrics(
     apply_preferred_aspect_ratio_layout(&mut layout, config);
 
     // Final pass: resolve all edge label positions using collision avoidance.
-    let label_start = Instant::now();
+    let label_start = crate::time::Instant::now();
     label_placement::resolve_all_label_positions(&mut layout, theme, config);
     if matches!(layout.diagram, DiagramData::Sequence(_)) {
         sequence::finalize_sequence_layout_bounds(&mut layout);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,6 +92,7 @@
 pub mod cli;
 pub mod config;
 mod edge_geometry;
+mod time;
 pub mod error;
 pub mod ir;
 pub mod layout;
@@ -339,8 +340,7 @@ pub fn render_with_detailed_timing(
     input: &str,
     options: RenderOptions,
 ) -> anyhow::Result<RenderDetailedResult> {
-    use std::time::Instant;
-
+    use crate::time::Instant;
     let t0 = Instant::now();
     let parsed = parse_mermaid(input)?;
     let parse_us = t0.elapsed().as_micros();

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,0 +1,20 @@
+/// WASM-compatible time shim.
+///
+/// On native targets this is a transparent re-export of `std::time::Instant`.
+/// On `wasm32-unknown-unknown` (which has no system clock) it is a zero-cost
+/// dummy that always reports zero elapsed time.  This lets the rest of the
+/// codebase use `Instant::now()` / `.elapsed()` without any `#[cfg]` guards.
+
+#[cfg(not(target_arch = "wasm32"))]
+pub use std::time::Instant;
+
+#[cfg(target_arch = "wasm32")]
+pub struct Instant;
+
+#[cfg(target_arch = "wasm32")]
+impl Instant {
+    #[inline(always)]
+    pub fn now() -> Self { Instant }
+    #[inline(always)]
+    pub fn elapsed(&self) -> std::time::Duration { std::time::Duration::ZERO }
+}


### PR DESCRIPTION
`std::time::Instant::now()` panics on `wasm32-unknown-unknown` with stable Rust.

This PR fixes WASM compatibility by introducing a thin `time` module that provides a transparent shim:
- On native targets: re-exports `std::time::Instant` unchanged
- On `wasm32-unknown-unknown`: provides a zero-cost mock that returns `Duration::ZERO`

This avoids scattering `#[cfg(not(target_arch = "wasm32"))]` guards throughout the codebase. The only change at call sites is importing `crate::time::Instant` instead of `std::time::Instant` in the three files that use it.

**Files changed:**
- `src/time.rs` — new WASM-compatible Instant shim
- `src/lib.rs` — use `crate::time::Instant` in `render_with_detailed_timing`
- `src/layout/mod.rs` — use `crate::time::Instant` for label placement timing
- `src/layout/flowchart/edge_pipeline.rs` — use `crate::time::Instant` for port/routing timing
