### PR TITLE
Fix/block beta nested groups

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3776,6 +3776,7 @@ fn parse_block_diagram(input: &str) -> Result<ParseOutput> {
     graph.direction = Direction::LeftRight;
     let (lines, init_config) = preprocess_input(input)?;
     let mut block = crate::ir::BlockDiagram::default();
+    let mut group_depth: usize = 0;
 
     for raw_line in lines {
         let line = raw_line.trim();
@@ -3783,9 +3784,37 @@ fn parse_block_diagram(input: &str) -> Result<ParseOutput> {
             continue;
         }
         let lower = line.to_ascii_lowercase();
-        if lower.starts_with("block") {
+
+        if lower.starts_with("block") && !lower.starts_with("block:") {
             continue;
         }
+
+        if lower.starts_with("block:") {
+            let rest = line[6..].trim();
+            let (token, span) = if let Some(colon) = rest.rfind(':')
+                && let Ok(n) = rest[colon + 1..].trim().parse::<usize>()
+                && n > 0
+            {
+                (rest[..colon].trim(), n)
+            } else {
+                (rest, 1usize)
+            };
+            let (id, label, shape, classes) = parse_node_token(token);
+            if !id.is_empty() {
+                graph.ensure_node(&id, label, shape);
+                if !classes.is_empty() {
+                    apply_node_classes(&mut graph, &id, &classes);
+                }
+                block.nodes.push(crate::ir::BlockNode {
+                    id,
+                    span,
+                    is_space: false,
+                });
+            }
+            group_depth += 1;
+            continue;
+        }
+
         if lower.starts_with("columns") {
             let parts: Vec<&str> = line.split_whitespace().collect();
             if parts.len() >= 2
@@ -3797,6 +3826,20 @@ fn parse_block_diagram(input: &str) -> Result<ParseOutput> {
             continue;
         }
         if lower == "end" {
+            group_depth = group_depth.saturating_sub(1);
+            continue;
+        }
+
+        if lower.starts_with("classdef ")
+            || lower == "classdef"
+            || lower.starts_with("class ")
+            || lower.starts_with("style ")
+            || lower.starts_with("linkstyle ")
+        {
+            continue;
+        }
+
+        if group_depth > 0 && parse_edge_line(line).is_none() {
             continue;
         }
         if let Some((left, label, right, edge_meta)) = parse_edge_line(line) {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -6103,53 +6103,35 @@ fn split_id_label(token: &str) -> Option<(&str, String, crate::ir::NodeShape)> {
 
 fn parse_shape_from_brackets(raw: &str) -> (String, crate::ir::NodeShape) {
     let trimmed = raw.trim();
-    if trimmed.starts_with("[/") && trimmed.ends_with("/]") {
-        return (
-            strip_quotes(&trimmed[2..trimmed.len() - 2]),
-            crate::ir::NodeShape::Parallelogram,
-        );
+    if let Some(inner) = strip_delimiters(trimmed, "[/", "/]") {
+        return (strip_quotes(inner), crate::ir::NodeShape::Parallelogram);
     }
-    if trimmed.starts_with("[\\") && trimmed.ends_with("\\]") {
-        return (
-            strip_quotes(&trimmed[2..trimmed.len() - 2]),
-            crate::ir::NodeShape::ParallelogramAlt,
-        );
+    if let Some(inner) = strip_delimiters(trimmed, "[\\", "\\]") {
+        return (strip_quotes(inner), crate::ir::NodeShape::ParallelogramAlt);
     }
-    if trimmed.starts_with("[/") && trimmed.ends_with("\\]") {
-        return (
-            strip_quotes(&trimmed[2..trimmed.len() - 2]),
-            crate::ir::NodeShape::Trapezoid,
-        );
+    if let Some(inner) = strip_delimiters(trimmed, "[/", "\\]") {
+        return (strip_quotes(inner), crate::ir::NodeShape::Trapezoid);
     }
-    if trimmed.starts_with("[\\") && trimmed.ends_with("/]") {
-        return (
-            strip_quotes(&trimmed[2..trimmed.len() - 2]),
-            crate::ir::NodeShape::TrapezoidAlt,
-        );
+    if let Some(inner) = strip_delimiters(trimmed, "[\\", "/]") {
+        return (strip_quotes(inner), crate::ir::NodeShape::TrapezoidAlt);
     }
-    if trimmed.starts_with("[[") && trimmed.ends_with("]]") {
-        return (
-            strip_quotes(&trimmed[2..trimmed.len() - 2]),
-            crate::ir::NodeShape::Subroutine,
-        );
+    if let Some(inner) = strip_delimiters(trimmed, "[[", "]]") {
+        return (strip_quotes(inner), crate::ir::NodeShape::Subroutine);
     }
-    if trimmed.starts_with("[(") && trimmed.ends_with(")]") {
-        return (
-            strip_quotes(&trimmed[2..trimmed.len() - 2]),
-            crate::ir::NodeShape::Cylinder,
-        );
+    if let Some(inner) = strip_delimiters(trimmed, "[(", ")]") {
+        return (strip_quotes(inner), crate::ir::NodeShape::Cylinder);
     }
-    if trimmed.starts_with("[") && trimmed.ends_with("]") {
-        let inner = &trimmed[1..trimmed.len() - 1];
-        if inner.starts_with('(') && inner.ends_with(')') {
-            return (
-                strip_quotes(&inner[1..inner.len() - 1]),
-                crate::ir::NodeShape::Stadium,
-            );
+    if let Some(inner) = strip_delimiters(trimmed, "[", "]") {
+        if let Some(stadium_inner) = strip_delimiters(inner, "(", ")") {
+            return (strip_quotes(stadium_inner), crate::ir::NodeShape::Stadium);
         }
         return (strip_quotes(inner), crate::ir::NodeShape::Rectangle);
     }
     (strip_quotes(trimmed), crate::ir::NodeShape::Rectangle)
+}
+
+fn strip_delimiters<'a>(s: &'a str, open: &str, close: &str) -> Option<&'a str> {
+    s.strip_prefix(open)?.strip_suffix(close)
 }
 
 fn parse_shape_from_parens(raw: &str) -> (String, crate::ir::NodeShape) {
@@ -7235,5 +7217,31 @@ A["foo & bar"] & B --> C"#;
             masked.len(),
             "masked string should have same byte length as original"
         );
+    }
+
+    #[test]
+    fn parse_flowchart_overlapping_shape_delimiters() {
+        // Overlapping shape delimiters fall through to a plain rectangle.
+        for (input, expected_label) in [("flowchart LR\nA[/]", "/"), ("flowchart LR\nA[\\]", "\\")]
+        {
+            let parsed = parse_mermaid(input).unwrap();
+            let node = parsed.graph.nodes.get("A").expect("node A missing");
+            assert_eq!(node.label, expected_label);
+            assert_eq!(node.shape, crate::ir::NodeShape::Rectangle);
+        }
+
+        // Same on the right-hand side of an edge.
+        for (input, expected_label) in [
+            ("flowchart LR\nA --> B[/]", "/"),
+            ("flowchart LR\nA --> B[\\]", "\\"),
+        ] {
+            let parsed = parse_mermaid(input).unwrap();
+            let b = parsed.graph.nodes.get("B").expect("node B missing");
+            assert_eq!(b.label, expected_label);
+            assert_eq!(b.shape, crate::ir::NodeShape::Rectangle);
+            assert_eq!(parsed.graph.edges.len(), 1);
+            assert_eq!(parsed.graph.edges[0].from, "A");
+            assert_eq!(parsed.graph.edges[0].to, "B");
+        }
     }
 }

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -41,7 +41,9 @@ pub fn validate(input: &str) -> Result<(), ParseError> {
     check_init_directive(&lines)?;
 
     // 2-3. Subgraph / end balance.
-    check_subgraph_balance(&lines)?;
+    if is_flowchart_diagram(&lines) {
+        check_subgraph_balance(&lines)?;
+    }
 
     // 4. Lines beginning with an arrow.
     check_leading_arrow(&lines)?;
@@ -127,6 +129,18 @@ fn check_init_directive(lines: &[&str]) -> Result<(), ParseError> {
 /// Tracks a stack of `subgraph` opening-line numbers. An `end`
 /// with an empty stack yields [`ParseError::UnexpectedToken`];
 /// a non-empty stack at EOF yields [`ParseError::UnclosedSubgraph`]
+fn is_flowchart_diagram(lines: &[&str]) -> bool {
+    for line in lines {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with("%%") {
+            continue;
+        }
+        let lower = trimmed.to_ascii_lowercase();
+        return lower.starts_with("flowchart") || lower.starts_with("graph ");
+    }
+    false
+}
+
 /// with the line of the outermost unclosed opening.
 fn check_subgraph_balance(lines: &[&str]) -> Result<(), ParseError> {
     let mut open_stack: Vec<u32> = Vec::new();

--- a/tests/fixtures/block/nested_groups.mmd
+++ b/tests/fixtures/block/nested_groups.mmd
@@ -1,0 +1,22 @@
+block-beta
+    columns 1
+    block:triggers["TRIGGERS"]
+        T["Cron | Webhook | Dashboard | Slack"]
+    end
+    block:orchestrator["ORCHESTRATOR"]
+        ORC["Reads context → Selects workflow → Spawns agents → Manages approval gates → Tracks progress"]
+    end
+    block:agents["AGENTS (LLM-Powered Decision Makers)"]
+        AG["Log Analyzer | Metrics Agent | Git Analyzer | Code Analyzer | Implementer | Verifier"]
+    end
+    block:tools["TOOLS (Dumb Executors — No LLM, Single Function, JSON In/Out)"]
+        TL["CloudWatch | Prometheus | Git CLI | Jira API | Slack API | Deploy CLI | Test Runner"]
+    end
+    block:state["MEMORY & STATE"]
+        ST["Session State | Workflow History | Run Artifacts | Config"]
+    end
+
+    triggers --> orchestrator
+    orchestrator --> agents
+    agents --> tools
+    agents --> state


### PR DESCRIPTION
 ## Summary
  
  Fixes two bugs that prevented `block-beta` and `sequenceDiagram` diagrams from rendering in Zed's markdown preview.

  **Validator (`src/validator.rs`)**
  The `check_subgraph_balance` check ran on all diagram types but only recognised `subgraph` as a block opener. Any `end`
  token in a non-flowchart diagram — such as `block:` groups in `block-beta` or `par`/`alt`/`loop` frames in
  `sequenceDiagram` — was incorrectly rejected with "unexpected token 'end'; expected matching subgraph". The check is now
   restricted to flowchart/graph diagrams where `subgraph`/`end` pairs are actually meaningful.
  
  **Parser (`src/parser.rs`)**
  In `parse_block_diagram`, the guard `lower.starts_with("block")` was intended to skip the diagram header but also
  silently dropped `block:id["Label"]` nested group declarations. This meant the group IDs used in edges were never
  created as nodes, producing a broken layout with phantom stub nodes. The fix parses `block:id["Label"]` declarations as
  named nodes, tracks nesting depth to skip inner nodes cleanly, and ignores `classDef`/`class`/`style`/`linkStyle`
  directives that don't belong in block diagrams.

  ## Test

  Added `tests/fixtures/block/nested_groups.mmd` covering a real-world `block-beta` diagram with named groups, column
  layout, and cross-group edges.

  Closes #102

