### PR TITLE
fix(flowchart): clear large center labels off their own routed path

### DIFF
--- a/src/layout/label_placement.rs
+++ b/src/layout/label_placement.rs
@@ -800,7 +800,23 @@ fn nudge_flowchart_labels_clear_of_own_paths(edges: &mut [EdgeLayout], bounds: O
             (-0.707, 0.707),
             (0.707, 0.707),
         ];
-        for step in [2.0, 4.0, 6.0, 8.0, 12.0, 16.0, 24.0, 32.0] {
+        // A label only needs to escape its own path by roughly half of its
+        // larger dimension plus the path's local extent. Small labels clear
+        // within the original 32px ceiling, but a large multi-line label on a
+        // short edge (the box can be taller than the edge's cross-axis span)
+        // needs a much larger displacement. Extend the step ladder to scale
+        // with the label so big labels can clear instead of being left
+        // overlapping their route. This pass runs last and only touches labels
+        // that already intersect their own path, so it cannot move a
+        // previously-clear label.
+        let reach = (label.width.max(label.height) + 48.0).max(64.0);
+        let mut steps = vec![2.0, 4.0, 6.0, 8.0, 12.0, 16.0, 24.0, 32.0];
+        let mut extra = 40.0;
+        while extra <= reach {
+            steps.push(extra);
+            extra += 8.0;
+        }
+        for step in steps {
             for (dx, dy) in directions {
                 let mut candidate = (center.0 + dx * step, center.1 + dy * step);
                 if let Some(bound) = bounds {


### PR DESCRIPTION
## Summary

Fixes a layout bug where a large multi-line edge label could be left overlapping its own routed path on a short edge.

The router reserves a label gap and detours the path around the reserved center, but the post-routing label de-overlap pass then relocates the label to avoid node/label collisions, which can drop the box back onto its own route. `nudge_flowchart_labels_clear_of_own_paths` is the final pass that moves such labels off their path, but its step ladder was capped at 32px. A tall label on a short edge — where the label box is taller than the edge's cross-axis span — needs a larger displacement than that to clear, so the pass gave up and left the overlap.

## Fix

Scale the nudge step ladder to the label size (`reach = max(w, h) + 48`) so large labels can escape their own path. The pass runs last and only relocates labels that already intersect their own path, so it cannot disturb a previously-clear label — no regression risk for labels that are already clear.

## Testing

- Reproduced on `flowchart_opaque` (edge Baldr->Ke2) in the layout-invariant suite; the label now clears its route.
- Full test suite green, no regressions.

Closes #105
