### PR TITLE
feat: add `info` diagram type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mermaid-rs-renderer"
 version = "0.2.2"
 edition = "2024"
-description = "Fast Mermaid diagram renderer in pure Rust - 23 diagram types, 100-1400x faster than mermaid-cli"
+description = "Fast Mermaid diagram renderer in pure Rust - 24 diagram types, 100-1400x faster than mermaid-cli"
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/1jehuang/mermaid-rs-renderer"

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ mmdr -i README.md -o ./diagrams/ -e svg
 
 ## Diagram Types
 
-mmdr supports **23 Mermaid diagram types**:
+mmdr supports **24 Mermaid diagram types**:
 
 | Category | Diagrams |
 |:---------|:---------|
@@ -157,7 +157,7 @@ mmdr supports **23 Mermaid diagram types**:
 | **Data** | ER Diagram, Pie Chart, XY Chart, Quadrant Chart, Sankey |
 | **Planning** | Gantt, Timeline, Journey, Kanban |
 | **Architecture** | C4, Block, Architecture, Requirement |
-| **Other** | Mindmap, Git Graph, ZenUML, Packet, Radar, Treemap |
+| **Other** | Mindmap, Git Graph, ZenUML, Packet, Radar, Treemap, Info |
 
 <table>
 <tr>
@@ -289,7 +289,7 @@ Supported:
 
 ## Features
 
-**Diagram types:** `flowchart` / `graph` | `sequenceDiagram` | `classDiagram` | `stateDiagram-v2` | `erDiagram` | `pie` | `gantt` | `journey` | `timeline` | `mindmap` | `gitGraph` | `xychart-beta` | `quadrantChart` | `sankey-beta` | `kanban` | `C4Context` | `block-beta` | `architecture-beta` | `requirementDiagram` | `zenuml` | `packet-beta` | `radar-beta` | `treemap`
+**Diagram types:** `flowchart` / `graph` | `sequenceDiagram` | `classDiagram` | `stateDiagram-v2` | `erDiagram` | `pie` | `gantt` | `journey` | `timeline` | `mindmap` | `gitGraph` | `xychart-beta` | `quadrantChart` | `sankey-beta` | `kanban` | `C4Context` | `block-beta` | `architecture-beta` | `requirementDiagram` | `zenuml` | `packet-beta` | `radar-beta` | `treemap` | `info`
 
 **Node shapes:** rectangle, round-rect, stadium, circle, double-circle, diamond, hexagon, cylinder, subroutine, trapezoid, parallelogram, asymmetric
 

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -33,6 +33,7 @@ pub enum DiagramKind {
     Radar,
     Treemap,
     XYChart,
+    Info,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/layout/info.rs
+++ b/src/layout/info.rs
@@ -1,0 +1,39 @@
+use std::collections::BTreeMap;
+
+use crate::ir::Graph;
+use crate::theme::Theme;
+
+use super::{DiagramData, InfoLayout, Layout};
+
+/// Width/height of the rendered `info` diagram, in viewbox units.
+///
+/// Mirrors the compact, fixed-size canvas Mermaid.js itself uses for the
+/// `info` diagram type (it has no graph content to size around).
+const INFO_VIEWBOX_WIDTH: f32 = 400.0;
+const INFO_VIEWBOX_HEIGHT: f32 = 100.0;
+const INFO_FONT_SCALE: f32 = 1.5;
+
+pub(super) fn compute_info_layout(graph: &Graph, theme: &Theme) -> Layout {
+    let width = INFO_VIEWBOX_WIDTH;
+    let height = INFO_VIEWBOX_HEIGHT;
+    let font_size = theme.font_size * INFO_FONT_SCALE;
+    let text = format!("mermaid-rs {}", env!("CARGO_PKG_VERSION"));
+
+    Layout {
+        kind: graph.kind,
+        nodes: BTreeMap::new(),
+        edges: Vec::new(),
+        subgraphs: Vec::new(),
+        width,
+        height,
+        diagram: DiagramData::Info(InfoLayout {
+            width,
+            height,
+            text,
+            text_x: width / 2.0,
+            // Baseline offset roughly centers the glyphs vertically.
+            text_y: height / 2.0 + font_size * 0.35,
+            font_size,
+        }),
+    }
+}

--- a/src/layout/invariants.rs
+++ b/src/layout/invariants.rs
@@ -768,6 +768,17 @@ pub fn validate_layout_invariants(layout: &Layout) -> Result<(), Vec<LayoutInvar
                 check_finite(&mut errors, path, value);
             }
         }
+        DiagramData::Info(info) => {
+            for (path, value) in [
+                ("info.width", info.width),
+                ("info.height", info.height),
+                ("info.text_x", info.text_x),
+                ("info.text_y", info.text_y),
+                ("info.font_size", info.font_size),
+            ] {
+                check_finite(&mut errors, path, value);
+            }
+        }
     }
 
     if layout.kind == DiagramKind::Flowchart {

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -6,6 +6,7 @@ mod flowchart;
 mod gantt;
 mod geometry;
 mod gitgraph;
+mod info;
 mod invariants;
 mod journey;
 mod kanban;
@@ -30,6 +31,7 @@ use c4::*;
 use error::*;
 use gantt::*;
 use gitgraph::*;
+use info::*;
 pub use invariants::{
     FlowchartQualityMetrics, LayoutInvariantError, flowchart_quality_metrics,
     validate_layout_invariants,
@@ -199,6 +201,7 @@ pub fn compute_layout_with_metrics(
         crate::ir::DiagramKind::XYChart => compute_xychart_layout(graph, theme, config),
         crate::ir::DiagramKind::Timeline => compute_timeline_layout(graph, theme, config),
         crate::ir::DiagramKind::Journey => compute_journey_layout(graph, theme, config),
+        crate::ir::DiagramKind::Info => compute_info_layout(graph, theme),
         crate::ir::DiagramKind::Class
         | crate::ir::DiagramKind::State
         | crate::ir::DiagramKind::Er

--- a/src/layout/types.rs
+++ b/src/layout/types.rs
@@ -284,6 +284,19 @@ pub struct GitGraphLayout {
     pub direction: Direction,
 }
 
+/// Layout for the dedicated `info` diagram, which (like Mermaid.js) has no
+/// graph content of its own: it always renders this crate's own name and
+/// version as a single centered text label.
+#[derive(Debug, Clone)]
+pub struct InfoLayout {
+    pub width: f32,
+    pub height: f32,
+    pub text: String,
+    pub text_x: f32,
+    pub text_y: f32,
+    pub font_size: f32,
+}
+
 #[derive(Debug, Clone)]
 pub struct ErrorLayout {
     pub viewbox_width: f32,
@@ -461,6 +474,7 @@ pub enum DiagramData {
     Timeline(TimelineLayout),
     Journey(JourneyLayout),
     Error(ErrorLayout),
+    Info(InfoLayout),
 }
 
 #[derive(Debug, Clone)]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -83,6 +83,7 @@ pub fn parse_mermaid(input: &str) -> Result<ParseOutput> {
         DiagramKind::Radar => parse_radar_diagram(input),
         DiagramKind::Treemap => parse_treemap_diagram(input),
         DiagramKind::XYChart => parse_xy_chart_diagram(input),
+        DiagramKind::Info => parse_info_diagram(input),
         DiagramKind::Flowchart => parse_flowchart(input),
     }
 }
@@ -196,6 +197,9 @@ fn detect_diagram_kind(input: &str) -> Option<DiagramKind> {
         }
         if starts_with_diagram_header(&lower, "xychart") {
             return Some(DiagramKind::XYChart);
+        }
+        if starts_with_diagram_header(&lower, "info") {
+            return Some(DiagramKind::Info);
         }
         if starts_with_diagram_header(&lower, "flowchart")
             || starts_with_diagram_header(&lower, "graph")
@@ -1708,6 +1712,16 @@ fn parse_er_diagram(input: &str) -> Result<ParseOutput> {
         node.label = lines.join("\n");
     }
 
+    Ok(ParseOutput { graph, init_config })
+}
+
+fn parse_info_diagram(input: &str) -> Result<ParseOutput> {
+    // The `info` diagram has no body syntax of its own (mirroring Mermaid.js):
+    // the header line alone is enough to select the dedicated info renderer,
+    // which always reports this crate's own name and version.
+    let mut graph = Graph::new();
+    graph.kind = DiagramKind::Info;
+    let (_lines, init_config) = preprocess_input(input)?;
     Ok(ParseOutput { graph, init_config })
 }
 
@@ -7245,5 +7259,19 @@ A["foo & bar"] & B --> C"#;
             masked.len(),
             "masked string should have same byte length as original"
         );
+    }
+
+    #[test]
+    fn detect_info_diagram() {
+        assert_eq!(detect_diagram_kind("info"), Some(DiagramKind::Info));
+        assert_eq!(detect_diagram_kind("  info  \n"), Some(DiagramKind::Info));
+    }
+
+    #[test]
+    fn parse_info_diagram_sets_kind() {
+        let parsed = parse_mermaid("info").unwrap();
+        assert_eq!(parsed.graph.kind, DiagramKind::Info);
+        assert!(parsed.graph.nodes.is_empty());
+        assert!(parsed.graph.edges.is_empty());
     }
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -6,7 +6,7 @@ use crate::layout::label_placement::{
 };
 use crate::layout::{
     C4BoundaryLayout, C4Layout, C4RelLayout, C4ShapeLayout, DiagramData, ErrorLayout,
-    GitGraphLayout, JourneyLayout, Layout, PieData, SankeyLayout, TextBlock,
+    GitGraphLayout, InfoLayout, JourneyLayout, Layout, PieData, SankeyLayout, TextBlock,
 };
 use crate::text_metrics;
 use crate::theme::{Theme, adjust_color, parse_color_to_hsl};
@@ -313,6 +313,12 @@ pub fn render_svg_with_dimensions(
 
     if let DiagramData::C4(ref c4) = layout.diagram {
         svg.push_str(&render_c4(c4, config));
+        svg.push_str("</svg>");
+        return svg;
+    }
+
+    if let DiagramData::Info(ref info) = layout.diagram {
+        svg.push_str(&render_info(info, theme));
         svg.push_str("</svg>");
         return svg;
     }
@@ -2202,6 +2208,19 @@ fn render_error(layout: &ErrorLayout, _theme: &Theme, _config: &LayoutConfig) ->
     svg.push_str("</g>");
 
     svg
+}
+
+fn render_info(layout: &InfoLayout, theme: &Theme) -> String {
+    let font_family = normalize_font_family(&theme.font_family);
+    format!(
+        "<text class=\"info-text\" x=\"{:.2}\" y=\"{:.2}\" font-family=\"{}\" font-size=\"{:.2}px\" fill=\"{}\" style=\"text-anchor: middle;\">{}</text>",
+        layout.text_x,
+        layout.text_y,
+        font_family,
+        layout.font_size,
+        theme.text_color,
+        escape_xml(&layout.text)
+    )
 }
 
 fn normalize_font_family(font_family: &str) -> String {
@@ -6388,6 +6407,17 @@ mod tests {
         assert!(svg.contains("id=\"edge-0\""));
         assert!(svg.contains("data-edge-id=\"edge-0\""));
         assert!(svg.contains("data-label-kind=\"center\""));
+    }
+
+    #[test]
+    fn render_svg_info_diagram() {
+        let mut graph = Graph::new();
+        graph.kind = crate::ir::DiagramKind::Info;
+        let layout = compute_layout(&graph, &Theme::modern(), &LayoutConfig::default());
+        let svg = render_svg(&layout, &Theme::modern(), &LayoutConfig::default());
+        let expected_text = format!("mermaid-rs {}", env!("CARGO_PKG_VERSION"));
+        assert!(svg.contains("<svg"));
+        assert!(svg.contains(&expected_text));
     }
 
     #[test]

--- a/tests/cli_suite.rs
+++ b/tests/cli_suite.rs
@@ -83,3 +83,47 @@ fn cli_width_height_affect_file_svg() {
     let _ = std::fs::remove_file(output_path);
     let _ = std::fs::remove_dir(dir);
 }
+
+#[test]
+fn cli_info_diagram_reports_crate_version() {
+    // Mirrors `echo "info" | cargo run -- -i - -o info.svg`: the `info`
+    // diagram has no body, just a header, and always renders this crate's
+    // own name and version (matching how Mermaid.js's own `info` diagram
+    // reports its version).
+    let dir = std::env::temp_dir().join(format!(
+        "mermaid-rs-renderer-cli-info-test-{}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&dir).expect("failed to create temp dir");
+    let output_path = dir.join("info.svg");
+
+    let mut child = mmdr()
+        .args(["-i", "-", "-o", output_path.to_str().unwrap()])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to run mmdr");
+    child
+        .stdin
+        .as_mut()
+        .expect("failed to open stdin")
+        .write_all(b"info\n")
+        .expect("failed to write stdin");
+    let output = child.wait_with_output().expect("failed to wait for mmdr");
+
+    assert!(
+        output.status.success(),
+        "mmdr failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let svg = std::fs::read_to_string(&output_path).expect("failed to read SVG output");
+    let expected_text = format!("mermaid-rs {}", env!("CARGO_PKG_VERSION"));
+    assert!(
+        svg.contains(&expected_text),
+        "expected info SVG to contain {expected_text:?}: {svg}"
+    );
+
+    let _ = std::fs::remove_file(output_path);
+    let _ = std::fs::remove_dir(dir);
+}


### PR DESCRIPTION
Mermaid.js has had the `info` diagram type for a while — run it and it
tells you which version of the renderer you're using. Thought it'd be
nice to have the same thing here.

```bash
echo "info" | mmdr -i - -o info.svg
```

The output is a clean SVG with `mermaid-rs 0.2.2` centered on it.
Nothing fancy, but it does a couple of things well:

**It mirrors the Mermaid.js experience.** Anyone who's used `info` in
the original knows exactly what to expect. The difference is the output
proudly says `mermaid-rs` instead of `mermaid`, so the moment someone
runs it they know they're on the Rust renderer — good for tooling
scripts that want to assert which backend they're talking to, and good
for the project's own identity.

**The version is always accurate.** It's pulled at compile time from
`Cargo.toml` via `env!("CARGO_PKG_VERSION")`, so there's nothing to
forget to update when the next release ships.

Under the hood it follows the same architecture as every other diagram
type — its own `layout/info.rs`, a `DiagramData::Info` variant, an
early-return render branch. No shortcuts. Tests cover detection,
parsing, rendering, and the full CLI stdin-to-SVG pipeline.