### PR TITLE
fix: wasm-safe Instant shim so layout profiler doesn't panic on wasm32

### DIFF
--- a/src/layout/flowchart/edge_pipeline.rs
+++ b/src/layout/flowchart/edge_pipeline.rs
@@ -1,6 +1,6 @@
+use crate::wasm_time::Instant;
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashMap};
-use std::time::Instant;
 
 use crate::config::LayoutConfig;
 use crate::ir::{DiagramKind, Graph};

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -55,10 +55,10 @@ use crate::config::{LayoutConfig, PieRenderMode, TreemapRenderMode};
 use crate::ir::{Direction, Graph};
 use crate::text_metrics;
 use crate::theme::{Theme, adjust_color, parse_color_to_hsl};
+use crate::wasm_time::Instant;
 use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashMap, HashSet};
-use std::time::Instant;
 
 // Label placement padding (resolved per diagram kind).
 // Minimum padding around the entire layout bounding box.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,6 +102,7 @@ mod text_metrics;
 pub mod theme;
 pub(crate) mod unicode_width;
 pub mod validator;
+mod wasm_time;
 
 // Re-export commonly used types at crate root for ergonomic library usage
 pub use config::{Config, LayoutConfig, RenderConfig, merge_init_config};
@@ -390,7 +391,7 @@ pub fn render_with_detailed_timing(
     input: &str,
     options: RenderOptions,
 ) -> anyhow::Result<RenderDetailedResult> {
-    use std::time::Instant;
+    use crate::wasm_time::Instant;
 
     let t0 = Instant::now();
     let parsed = parse_mermaid(input)?;

--- a/src/wasm_time.rs
+++ b/src/wasm_time.rs
@@ -1,0 +1,26 @@
+//! wasm-safe monotonic timer shim.
+//!
+//! `std::time::Instant::now()` panics on `wasm32-unknown-unknown`
+//! ("time not implemented on this platform"). The layout profiler uses
+//! `Instant` only to populate discarded `stage_metrics.*_us` counters, so on
+//! wasm we substitute a zero-cost stub that reports a zero elapsed duration.
+//! Native builds re-export the real `std::time::Instant` unchanged.
+
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) use std::time::Instant;
+
+#[cfg(target_arch = "wasm32")]
+#[derive(Clone, Copy)]
+pub(crate) struct Instant;
+
+#[cfg(target_arch = "wasm32")]
+impl Instant {
+    #[inline]
+    pub(crate) fn now() -> Self {
+        Instant
+    }
+    #[inline]
+    pub(crate) fn elapsed(&self) -> std::time::Duration {
+        std::time::Duration::ZERO
+    }
+}


### PR DESCRIPTION
## Problem

`std::time::Instant::now()` panics at **runtime** on `wasm32-unknown-unknown`
with the message *"time not implemented on this platform"*. The layout profiler
calls it unconditionally, so `compute_layout` traps in any browser / `wasmi`
runtime. The call sites on the normal render path:

- `src/layout/mod.rs:214` — `let label_start = Instant::now();`
- `src/layout/flowchart/edge_pipeline.rs:2148` — `let port_assignment_start = Instant::now();`
- `src/layout/flowchart/edge_pipeline.rs:2466` — `let edge_routing_start = Instant::now();`
- `src/lib.rs:395` (`render_with_detailed_timing`) — `let t0 = Instant::now();` (+ 401, 405)

This is the crash behind #64 ("Runtime panic occurs when compiling to wasm in
typst"), and the compiler gives no warning — `cargo check --target
wasm32-unknown-unknown` is green on `master`, so the failure only surfaces at
runtime, which makes it easy to miss.

## Fix

A thin `src/wasm_time.rs` shim, imported at the four call sites in place of
`std::time::Instant`:

- **native**: `pub(crate) use std::time::Instant;` — the exact same type, zero overhead, behavior unchanged.
- **wasm32**: a zero-cost stub whose `elapsed()` returns `Duration::ZERO`.

No `Instant::now()` / `.elapsed()` call is changed — only the import path. The
timers feed only the `stage_metrics.*_us` counters, which are already discarded
on the normal render path, so on native this is a no-op (`crate::wasm_time::Instant`
*is* `std::time::Instant`).

Diff is 4 files, +30/-3.

## Verification

- `cargo check` (native, default features) — green
- `cargo check --target wasm32-unknown-unknown --no-default-features` — green
- `cargo fmt -- --check` — green
- `cargo test --lib` / `cargo test --no-default-features --lib` — no new failures introduced
- Confirmed the shim introduces **zero** new `clippy` findings; on native the layout output is byte-identical (import-only change).

> Heads-up, unrelated to this PR: `master` HEAD currently has a pre-existing
> `clippy -D warnings` dead-code error (`axis_label_width`, `src/layout/radar.rs:86`)
> and one failing layout test (`cycle_fixture_subgraph_entry_aligns_with_spine`).
> Both reproduce on a clean `master` checkout without this patch; this PR touches
> neither and doesn't change their status.

## Context & prior art

We compile this crate to `wasm32-unknown-unknown` for in-browser SVG rendering in
production, and with this one shim it works beautifully. This is the same
approach as #97 / #98, rebased onto current `master` and reduced to just the
`Instant` concern (no unrelated changes) so it applies cleanly — happy to defer
to those PRs or adjust naming (`wasm_time` vs `time`) if you prefer. Also relevant:
#64 (root-cause report) and #120 (wasm demand).
