### PR TITLE
Fix/nested subgraph layout

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -27,9 +27,9 @@ pub struct Args {
     #[arg(short = 'o', long = "output")]
     pub output: Option<PathBuf>,
 
-    /// Output format
-    #[arg(short = 'e', long = "outputFormat", value_enum, default_value = "svg")]
-    pub output_format: OutputFormat,
+    /// Output format. Defaults to the output file's extension, else svg.
+    #[arg(short = 'e', long = "outputFormat", value_enum)]
+    pub output_format: Option<OutputFormat>,
 
     /// Config JSON file (Mermaid-like themeVariables)
     #[arg(short = 'c', long = "configFile")]
@@ -89,6 +89,21 @@ pub struct Args {
 pub enum OutputFormat {
     Svg,
     Png,
+}
+
+impl Args {
+    /// Format to write: an explicit `-e` wins, else the output file's
+    /// extension, else SVG. Without the extension fallback `-o diagram.png`
+    /// silently wrote SVG bytes into a `.png`.
+    pub fn resolved_output_format(&self) -> OutputFormat {
+        if let Some(format) = self.output_format {
+            return format;
+        }
+        match self.output.as_deref().and_then(Path::extension) {
+            Some(ext) if ext.eq_ignore_ascii_case("png") => OutputFormat::Png,
+            _ => OutputFormat::Svg,
+        }
+    }
 }
 
 #[derive(ValueEnum, Debug, Clone, Copy)]
@@ -211,7 +226,7 @@ pub fn run() -> Result<()> {
             render_svg_with_dimensions(&layout, &config.theme, &config.layout, explicit_dimensions);
         let render_us = t_render_start.elapsed().as_micros();
 
-        match args.output_format {
+        match args.resolved_output_format() {
             OutputFormat::Svg => {
                 write_output_svg(&svg, args.output.as_deref())?;
             }
@@ -282,8 +297,11 @@ pub fn run() -> Result<()> {
         return Ok(());
     }
 
-    let outputs =
-        resolve_multi_outputs(args.output.as_deref(), args.output_format, diagrams.len())?;
+    let outputs = resolve_multi_outputs(
+        args.output.as_deref(),
+        args.resolved_output_format(),
+        diagrams.len(),
+    )?;
     for (idx, diagram) in diagrams.iter().enumerate() {
         let parsed = parse_mermaid(diagram)?;
         let mut config = base_config.clone();
@@ -310,7 +328,7 @@ pub fn run() -> Result<()> {
         }
         let svg =
             render_svg_with_dimensions(&layout, &config.theme, &config.layout, explicit_dimensions);
-        match args.output_format {
+        match args.resolved_output_format() {
             OutputFormat::Svg => {
                 write_output_svg(&svg, Some(&outputs[idx]))?;
             }

--- a/src/layout/flowchart/edge_pipeline.rs
+++ b/src/layout/flowchart/edge_pipeline.rs
@@ -657,6 +657,65 @@ fn candidate_vertical_sides(from: &NodeLayout, to: &NodeLayout) -> (EdgeSide, Ed
     }
 }
 
+/// Lateral "sidestep" ports for a main-axis edge: leave and re-enter on the
+/// same flank so the route can use a free channel running alongside the nodes.
+///
+/// When the corridor between two stacked nodes is blocked at both ends -- a
+/// wide neighbour directly below the source and another directly above the
+/// target -- every opposite-side pairing has to cut back across the diagram to
+/// reach a clear channel. Exiting and entering on the same flank lets the route
+/// drop straight down that channel instead. The nearer flank is offered first
+/// so it survives a tight `max_candidates` budget.
+///
+/// Only offered when the edge leaves one subgraph frame for another. That is
+/// where the blocked corridor comes from: the frames themselves fill the main
+/// axis between the two nodes, so no ordinary pairing has anywhere to go. Among
+/// free-standing nodes the corridor is open and the conventional pairings route
+/// it well, while a same-flank offer there only displaces the port assignment
+/// of the neighbours that share those sides.
+fn sidestep_side_candidates(
+    from: &NodeLayout,
+    to: &NodeLayout,
+    direction: crate::ir::Direction,
+    obstacles: &[Obstacle],
+) -> Option<[(EdgeSide, EdgeSide, bool); 2]> {
+    let crosses_frame = obstacles.iter().any(|obstacle| {
+        obstacle
+            .members
+            .as_ref()
+            .is_some_and(|members| members.contains(&from.id) != members.contains(&to.id))
+    });
+    if !crosses_frame {
+        return None;
+    }
+
+    let from_c = node_center(from);
+    let to_c = node_center(to);
+    Some(if is_horizontal(direction) {
+        if to_c.1 <= from_c.1 {
+            [
+                (EdgeSide::Top, EdgeSide::Top, false),
+                (EdgeSide::Bottom, EdgeSide::Bottom, false),
+            ]
+        } else {
+            [
+                (EdgeSide::Bottom, EdgeSide::Bottom, false),
+                (EdgeSide::Top, EdgeSide::Top, false),
+            ]
+        }
+    } else if to_c.0 <= from_c.0 {
+        [
+            (EdgeSide::Left, EdgeSide::Left, false),
+            (EdgeSide::Right, EdgeSide::Right, false),
+        ]
+    } else {
+        [
+            (EdgeSide::Right, EdgeSide::Right, false),
+            (EdgeSide::Left, EdgeSide::Left, false),
+        ]
+    })
+}
+
 fn branching_fan_side_candidates(
     from: &NodeLayout,
     to: &NodeLayout,
@@ -935,6 +994,7 @@ fn collect_routed_side_candidates(
     edge_role: roles::FlowchartEdgeRole,
     graph_direction: crate::ir::Direction,
     content_bounds: Option<NodeBounds>,
+    obstacles: &[Obstacle],
     limit: usize,
 ) -> Vec<(EdgeSide, EdgeSide, bool)> {
     let mut candidates = Vec::with_capacity(limit.max(1));
@@ -972,6 +1032,13 @@ fn collect_routed_side_candidates(
             choose_outer_back_edge_sides(from, to, graph_direction, content_bounds, balanced),
             limit,
         );
+    }
+    // Offered last, so they only fill slots the conventional pairings left free.
+    for sidestep in sidestep_side_candidates(from, to, graph_direction, obstacles)
+        .into_iter()
+        .flatten()
+    {
+        push_unique_side_candidate_limited(&mut candidates, sidestep, limit);
     }
     candidates
 }
@@ -1117,6 +1184,7 @@ fn choose_routed_flowchart_sides(
         edge_role,
         ctx.graph_direction,
         ctx.content_bounds,
+        ctx.obstacles,
         ctx.profile.max_candidates,
     );
 
@@ -1539,6 +1607,7 @@ fn refine_flowchart_ports_with_route_candidates(
             edge_role,
             ctx.graph.direction,
             ctx.content_bounds,
+            ctx.obstacles,
             ctx.profile.max_candidates,
         );
         // Back edges have their sides chosen deliberately so they exit into an
@@ -3294,6 +3363,7 @@ mod tests {
             roles::FlowchartEdgeRole::default(),
             crate::ir::Direction::TopDown,
             None,
+            &[],
             3,
         );
         assert_eq!(bounded.len(), 3);

--- a/src/layout/flowchart/subgraph_spacing.rs
+++ b/src/layout/flowchart/subgraph_spacing.rs
@@ -8,7 +8,7 @@ use crate::theme::Theme;
 use super::super::routing::is_horizontal;
 use super::super::{
     MIN_NODE_SPACING_FLOOR, NodeLayout, SUBGRAPH_DESIRED_GAP_RATIO, build_subgraph_layouts,
-    measure_label, subgraph_anchor_id, subgraph_padding_from_label, top_level_subgraph_indices,
+    subgraph_anchor_id, top_level_subgraph_indices,
 };
 
 fn is_region_subgraph(sub: &crate::ir::Subgraph) -> bool {
@@ -520,35 +520,16 @@ pub(in crate::layout) fn separate_sibling_subgraphs(
 
     let horizontal = is_horizontal(graph.direction);
     for group in sibling_groups {
+        // Measure the frames as they will be drawn. A parent that contains
+        // nested children is taller and wider than the members it declares, and
+        // separating on the smaller rect leaves the drawn boxes overlapping.
+        let rects = super::super::subgraphs::rendered_subgraph_rects(graph, nodes, theme, config);
         let mut bounds: Vec<(usize, f32, f32, f32, f32)> = Vec::new();
         for &idx in &group {
-            let sub = &graph.subgraphs[idx];
-            let mut min_x = f32::MAX;
-            let mut min_y = f32::MAX;
-            let mut max_x = f32::MIN;
-            let mut max_y = f32::MIN;
-            for node_id in &sub.nodes {
-                if let Some(node) = nodes.get(node_id) {
-                    min_x = min_x.min(node.x);
-                    min_y = min_y.min(node.y);
-                    max_x = max_x.max(node.x + node.width);
-                    max_y = max_y.max(node.y + node.height);
-                }
-            }
-            if min_x == f32::MAX {
+            let Some([min_x, min_y, max_x, max_y]) = rects.get(idx).copied().flatten() else {
                 continue;
-            }
-
-            let label_block = measure_label(&sub.label, theme, config);
-            let (pad_x, pad_y, top_padding) =
-                subgraph_padding_from_label(graph, sub, theme, &label_block);
-            bounds.push((
-                idx,
-                min_x - pad_x,
-                min_y - top_padding,
-                max_x + pad_x,
-                max_y + pad_y,
-            ));
+            };
+            bounds.push((idx, min_x, min_y, max_x, max_y));
         }
 
         if bounds.len() < 2 {

--- a/src/layout/flowchart/subgraph_spacing.rs
+++ b/src/layout/flowchart/subgraph_spacing.rs
@@ -392,6 +392,10 @@ pub(in crate::layout) fn enforce_top_level_subgraph_gap(
         max_x: f32,
         max_y: f32,
         pad_main: f32,
+        /// Main-axis start of the *member nodes*, before label padding is
+        /// applied. Padding depends on the title's wrapped height, so sorting
+        /// on the padded bound would let a two-line title reorder the frames.
+        content_main: f32,
     }
 
     let horizontal = is_horizontal(graph.direction);
@@ -418,6 +422,7 @@ pub(in crate::layout) fn enforce_top_level_subgraph_gap(
             max_x: max_x + pad_x,
             max_y: max_y + pad_y,
             pad_main: if horizontal { pad_x } else { pad_y },
+            content_main: if horizontal { min_x } else { min_y },
         });
     }
 
@@ -426,10 +431,8 @@ pub(in crate::layout) fn enforce_top_level_subgraph_gap(
     }
 
     bounds.sort_by(|a, b| {
-        let a_key = if horizontal { a.min_x } else { a.min_y };
-        let b_key = if horizontal { b.min_x } else { b.min_y };
-        a_key
-            .partial_cmp(&b_key)
+        a.content_main
+            .partial_cmp(&b.content_main)
             .unwrap_or(Ordering::Equal)
             .then_with(|| a.idx.cmp(&b.idx))
     });

--- a/src/layout/flowchart/subgraph_spacing.rs
+++ b/src/layout/flowchart/subgraph_spacing.rs
@@ -222,21 +222,10 @@ pub(in crate::layout) fn debug_assert_flowchart_node_layout_invariants(
             continue;
         }
 
-        let mut min_x = f32::MAX;
-        let mut min_y = f32::MAX;
-        let mut max_x = f32::MIN;
-        let mut max_y = f32::MIN;
-        for node_id in &sub.nodes {
-            if let Some(node) = nodes.get(node_id) {
-                min_x = min_x.min(node.x);
-                min_y = min_y.min(node.y);
-                max_x = max_x.max(node.x + node.width);
-                max_y = max_y.max(node.y + node.height);
-            }
-        }
-        if min_x == f32::MAX {
+        let Some((min_x, min_y, max_x, max_y)) = super::super::node_bounds(nodes, &sub.nodes)
+        else {
             continue;
-        }
+        };
         bounds.push(Bounds {
             label: sub.label.as_str(),
             min_x,
@@ -414,30 +403,13 @@ pub(in crate::layout) fn enforce_top_level_subgraph_gap(
             continue;
         }
 
-        let mut min_x = f32::MAX;
-        let mut min_y = f32::MAX;
-        let mut max_x = f32::MIN;
-        let mut max_y = f32::MIN;
-        for node_id in &sub.nodes {
-            if let Some(node) = nodes.get(node_id) {
-                min_x = min_x.min(node.x);
-                min_y = min_y.min(node.y);
-                max_x = max_x.max(node.x + node.width);
-                max_y = max_y.max(node.y + node.height);
-            }
-        }
-        if min_x == f32::MAX {
+        let Some((min_x, min_y, max_x, max_y)) = super::super::node_bounds(nodes, &sub.nodes)
+        else {
             continue;
-        }
+        };
 
-        let label_empty = sub.label.trim().is_empty();
-        let mut label_block = measure_label(&sub.label, theme, config);
-        if label_empty {
-            label_block.width = 0.0;
-            label_block.height = 0.0;
-        }
-        let (pad_x, pad_y, top_padding) =
-            subgraph_padding_from_label(graph, sub, theme, &label_block);
+        let (_, (pad_x, pad_y, top_padding)) =
+            super::super::subgraph_label_metrics(graph, sub, theme, config);
 
         bounds.push(Bounds {
             idx,
@@ -716,18 +688,10 @@ pub(in crate::layout) fn align_disconnected_top_level_subgraphs(
         if sub.nodes.is_empty() {
             continue;
         }
-        let mut min_x = f32::MAX;
-        let mut min_y = f32::MAX;
-        let mut max_x = f32::MIN;
-        let mut max_y = f32::MIN;
-        for node_id in &sub.nodes {
-            if let Some(node) = nodes.get(node_id) {
-                min_x = min_x.min(node.x);
-                min_y = min_y.min(node.y);
-                max_x = max_x.max(node.x + node.width);
-                max_y = max_y.max(node.y + node.height);
-            }
-        }
+        let (mut min_x, mut min_y, mut max_x, mut max_y) = super::super::node_bounds(
+            nodes, &sub.nodes,
+        )
+        .unwrap_or((f32::MAX, f32::MAX, f32::MIN, f32::MIN));
         let anchor_id = subgraph_anchor_id(sub, nodes).map(|id| id.to_string());
         if let Some(anchor) = anchor_id.as_deref().and_then(|id| nodes.get(id)) {
             min_x = min_x.min(anchor.x);
@@ -992,21 +956,10 @@ pub(in crate::layout) fn align_disconnected_components(
 
     let mut bounds: Vec<ComponentBounds> = Vec::new();
     for component in components {
-        let mut min_x = f32::MAX;
-        let mut min_y = f32::MAX;
-        let mut max_x = f32::MIN;
-        let mut max_y = f32::MIN;
-        for node_id in &component {
-            if let Some(node) = nodes.get(node_id) {
-                min_x = min_x.min(node.x);
-                min_y = min_y.min(node.y);
-                max_x = max_x.max(node.x + node.width);
-                max_y = max_y.max(node.y + node.height);
-            }
-        }
-        if min_x == f32::MAX {
+        let Some((min_x, min_y, max_x, max_y)) = super::super::node_bounds(nodes, &component)
+        else {
             continue;
-        }
+        };
         bounds.push(ComponentBounds {
             nodes: component,
             min_x,

--- a/src/layout/kanban.rs
+++ b/src/layout/kanban.rs
@@ -47,14 +47,8 @@ pub(super) fn compute_kanban_layout(
         }
         assigned.extend(column_nodes.iter().cloned());
 
-        let label_empty = sub.label.trim().is_empty();
-        let mut label_block = measure_label(&sub.label, theme, config);
-        if label_empty {
-            label_block.width = 0.0;
-            label_block.height = 0.0;
-        }
-        let (pad_x, _pad_y, top_padding) =
-            subgraph_padding_from_label(graph, sub, theme, &label_block);
+        let (label_block, (pad_x, _pad_y, top_padding)) =
+            subgraph_label_metrics(graph, sub, theme, config);
 
         let max_node_width = column_nodes
             .iter()

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -736,7 +736,14 @@ fn compute_flowchart_layout(
         config,
     );
 
-    apply_subgraph_node_layout_passes(graph, &mut nodes, config, &anchored_indices, &anchor_info);
+    apply_subgraph_node_layout_passes(
+        graph,
+        &mut nodes,
+        theme,
+        config,
+        &anchored_indices,
+        &anchor_info,
+    );
 
     flowchart::subgraph_spacing::apply_flowchart_node_layout_cleanup(
         graph, &mut nodes, theme, config,
@@ -749,7 +756,7 @@ fn compute_flowchart_layout(
         &effective_config,
         fold_outcome.is_some(),
     );
-    apply_subgraph_direction_overrides(graph, &mut nodes, config, &anchored_indices);
+    apply_subgraph_direction_overrides(graph, &mut nodes, theme, config, &anchored_indices);
     // Objective and direction passes can shift whole top-level groups after the
     // initial subgraph cleanup. Re-apply the non-overlap spacing constraints
     // before subgraph boxes are materialized so dense cross-subgraph flowcharts
@@ -865,9 +872,32 @@ fn assign_positions(
         bucket.sort_by_key(|id| node_order.get(id.as_str()).copied().unwrap_or(usize::MAX));
     }
 
+    // Cross extent of every rank, so the ranks can be centred on each other
+    // rather than flush-aligned against the leading edge. Two nodes joined
+    // across ranks then line up on their centres, which is what a reader
+    // expects of a straight edge between them.
+    let cross_extents: Vec<f32> = rank_nodes
+        .iter()
+        .map(|bucket| {
+            let mut extent = 0.0f32;
+            for node_id in bucket {
+                if let Some(node) = nodes.get(node_id.as_str()) {
+                    let size = if is_horizontal(direction) {
+                        node.height
+                    } else {
+                        node.width
+                    };
+                    extent += size + config.node_spacing;
+                }
+            }
+            (extent - config.node_spacing).max(0.0)
+        })
+        .collect();
+    let widest_rank = cross_extents.iter().copied().fold(0.0f32, f32::max);
+
     let mut main_cursor = 0.0;
-    for bucket in rank_nodes {
-        let mut cross_cursor = 0.0;
+    for (rank, bucket) in rank_nodes.into_iter().enumerate() {
+        let mut cross_cursor = (widest_rank - cross_extents[rank]) * 0.5;
         let mut max_main: f32 = 0.0;
         for node_id in bucket {
             if let Some(node) = nodes.get_mut(&node_id) {

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -888,6 +888,38 @@ fn assign_positions(
     }
 }
 
+/// Union of the rects of `ids` that are actually placed in `nodes`, as
+/// `(min_x, min_y, max_x, max_y)`. `None` when none of them is.
+///
+/// Subgraph geometry is derived from a member list in a dozen places; each one
+/// used to spell this loop out and re-check the `f32::MAX` sentinel by hand.
+pub(in crate::layout) fn node_bounds<I, S>(
+    nodes: &BTreeMap<String, NodeLayout>,
+    ids: I,
+) -> Option<(f32, f32, f32, f32)>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let mut bounds: Option<(f32, f32, f32, f32)> = None;
+    for id in ids {
+        let Some(node) = nodes.get(id.as_ref()) else {
+            continue;
+        };
+        let rect = (node.x, node.y, node.x + node.width, node.y + node.height);
+        bounds = Some(match bounds {
+            None => rect,
+            Some(acc) => (
+                acc.0.min(rect.0),
+                acc.1.min(rect.1),
+                acc.2.max(rect.2),
+                acc.3.max(rect.3),
+            ),
+        });
+    }
+    bounds
+}
+
 fn bounds_without_padding(
     nodes: &BTreeMap<String, NodeLayout>,
     subgraphs: &[SubgraphLayout],
@@ -1372,18 +1404,8 @@ fn push_non_members_out_of_subgraphs(
     // Compute subgraph bounds from their member nodes
     let mut sub_bounds: Vec<(f32, f32, f32, f32)> = Vec::new();
     for sub in &graph.subgraphs {
-        let mut min_x = f32::MAX;
-        let mut min_y = f32::MAX;
-        let mut max_x = f32::MIN;
-        let mut max_y = f32::MIN;
-        for node_id in &sub.nodes {
-            if let Some(node) = nodes.get(node_id) {
-                min_x = min_x.min(node.x);
-                min_y = min_y.min(node.y);
-                max_x = max_x.max(node.x + node.width);
-                max_y = max_y.max(node.y + node.height);
-            }
-        }
+        let (min_x, min_y, max_x, max_y) =
+            node_bounds(nodes, &sub.nodes).unwrap_or((f32::MAX, f32::MAX, f32::MIN, f32::MIN));
         let (pad_x, pad_y, top_pad) = subgraph_padding_from_label(
             graph,
             sub,

--- a/src/layout/ranking.rs
+++ b/src/layout/ranking.rs
@@ -27,11 +27,138 @@ pub(super) fn rank_edges_for_manual_layout(
         covered.insert(edge.to.as_str());
     }
     let min_covered = layout_node_ids.len().div_ceil(2);
-    if covered.len() >= min_covered {
-        return primary;
+    let base = if covered.len() >= min_covered {
+        primary
+    } else {
+        layout_edges.to_vec()
+    };
+
+    with_subgraph_band_constraints(graph, layout_node_ids, layout_edges, base)
+}
+
+/// Cap on synthetic edges generated for one subgraph pair, so a pair of wide
+/// frames cannot blow the rank graph up quadratically.
+const MAX_BAND_CONSTRAINTS_PER_PAIR: usize = 64;
+
+/// Keep the members of chained subgraphs in disjoint rank bands.
+///
+/// Rank assignment is otherwise subgraph-blind: a member with no incoming edge
+/// (the top row of a frame) lands on rank 0 whichever subgraph it belongs to,
+/// so `A -> B -> C` chains leave all three frames starting on the same rank and
+/// overlapping. When a cross-subgraph edge orders two frames, every member of
+/// the source frame should rank before every member of the target frame; edges
+/// from the source's internal sinks to the target's internal sources impose
+/// exactly that. These are ranking-only inputs and are never rendered.
+///
+/// Deliberately conservative: nested subgraphs, overlapping membership, and
+/// mutually-connected frames are all left alone.
+fn with_subgraph_band_constraints(
+    graph: &Graph,
+    layout_node_ids: &[String],
+    layout_edges: &[crate::ir::Edge],
+    mut edges: Vec<crate::ir::Edge>,
+) -> Vec<crate::ir::Edge> {
+    let top_level = super::subgraphs::top_level_subgraph_indices(graph);
+    // Nested frames make "the band of a node" ambiguous, so only handle the
+    // flat case where every declared subgraph is top level.
+    if top_level.len() < 2 || top_level.len() != graph.subgraphs.len() {
+        return edges;
     }
 
-    layout_edges.to_vec()
+    let layout_set: HashSet<&str> = layout_node_ids.iter().map(String::as_str).collect();
+    let mut owner: HashMap<&str, usize> = HashMap::new();
+    for &idx in &top_level {
+        for member in &graph.subgraphs[idx].nodes {
+            if !layout_set.contains(member.as_str()) {
+                continue;
+            }
+            if owner.insert(member.as_str(), idx).is_some() {
+                // A node claimed by two frames: bands are not well defined.
+                return edges;
+            }
+        }
+    }
+
+    // Order frames by the real edges running between them, ignoring any pair
+    // that is connected both ways (that is a cycle, not a chain).
+    let mut forward: HashSet<(usize, usize)> = HashSet::new();
+    for edge in layout_edges {
+        let (Some(&from_sg), Some(&to_sg)) =
+            (owner.get(edge.from.as_str()), owner.get(edge.to.as_str()))
+        else {
+            continue;
+        };
+        if from_sg != to_sg {
+            forward.insert((from_sg, to_sg));
+        }
+    }
+    let mut pairs: Vec<(usize, usize)> = forward
+        .iter()
+        .copied()
+        .filter(|&(a, b)| !forward.contains(&(b, a)))
+        .collect();
+    if pairs.is_empty() {
+        return edges;
+    }
+    pairs.sort_unstable();
+
+    // Internal sinks/sources, computed over intra-frame edges only.
+    let mut has_incoming: HashSet<&str> = HashSet::new();
+    let mut has_outgoing: HashSet<&str> = HashSet::new();
+    for edge in layout_edges {
+        let (Some(&from_sg), Some(&to_sg)) =
+            (owner.get(edge.from.as_str()), owner.get(edge.to.as_str()))
+        else {
+            continue;
+        };
+        if from_sg == to_sg {
+            has_outgoing.insert(edge.from.as_str());
+            has_incoming.insert(edge.to.as_str());
+        }
+    }
+    let frame_members = |idx: usize| -> Vec<&str> {
+        graph.subgraphs[idx]
+            .nodes
+            .iter()
+            .map(String::as_str)
+            .filter(|id| layout_set.contains(id))
+            .collect()
+    };
+
+    let template = edges.first().or(layout_edges.first()).cloned();
+    let Some(template) = template else {
+        return edges;
+    };
+
+    for (from_sg, to_sg) in pairs {
+        let sinks: Vec<&str> = frame_members(from_sg)
+            .into_iter()
+            .filter(|id| !has_outgoing.contains(id))
+            .collect();
+        let sources: Vec<&str> = frame_members(to_sg)
+            .into_iter()
+            .filter(|id| !has_incoming.contains(id))
+            .collect();
+        if sinks.is_empty()
+            || sources.is_empty()
+            || sinks.len() * sources.len() > MAX_BAND_CONSTRAINTS_PER_PAIR
+        {
+            continue;
+        }
+        for sink in &sinks {
+            for source in &sources {
+                let mut constraint = template.clone();
+                constraint.from = (*sink).to_string();
+                constraint.to = (*source).to_string();
+                constraint.label = None;
+                constraint.start_label = None;
+                constraint.end_label = None;
+                edges.push(constraint);
+            }
+        }
+    }
+
+    edges
 }
 
 pub(super) fn order_rank_nodes(

--- a/src/layout/subgraphs.rs
+++ b/src/layout/subgraphs.rs
@@ -481,6 +481,7 @@ pub(super) fn top_level_subgraph_indices(graph: &Graph) -> Vec<usize> {
 pub(super) fn apply_subgraph_node_layout_passes(
     graph: &Graph,
     nodes: &mut BTreeMap<String, NodeLayout>,
+    theme: &Theme,
     config: &LayoutConfig,
     anchored_indices: &HashSet<usize>,
     anchor_info: &HashMap<String, SubgraphAnchorInfo>,
@@ -490,10 +491,10 @@ pub(super) fn apply_subgraph_node_layout_passes(
     }
 
     if graph.kind != DiagramKind::State {
-        apply_subgraph_direction_overrides(graph, nodes, config, anchored_indices);
+        apply_subgraph_direction_overrides(graph, nodes, theme, config, anchored_indices);
     }
     if !anchor_info.is_empty() {
-        let _ = align_subgraphs_to_anchor_nodes(graph, anchor_info, nodes, config);
+        let _ = align_subgraphs_to_anchor_nodes(graph, anchor_info, nodes, theme, config);
     }
     if graph.kind == DiagramKind::State && !anchor_info.is_empty() {
         apply_state_subgraph_layouts(graph, nodes, config, anchored_indices);
@@ -512,9 +513,11 @@ pub(super) fn apply_subgraph_node_layout_passes(
 pub(super) fn apply_subgraph_direction_overrides(
     graph: &Graph,
     nodes: &mut BTreeMap<String, NodeLayout>,
+    theme: &Theme,
     config: &LayoutConfig,
     skip_indices: &HashSet<usize>,
 ) {
+    let tree = SubgraphTree::build(graph);
     for (idx, sub) in graph.subgraphs.iter().enumerate() {
         if skip_indices.contains(&idx) {
             continue;
@@ -539,48 +542,20 @@ pub(super) fn apply_subgraph_direction_overrides(
             continue;
         };
 
-        let mut temp_nodes: BTreeMap<String, NodeLayout> = BTreeMap::new();
-        for node_id in &sub.nodes {
-            if let Some(node) = nodes.get(node_id) {
-                let mut clone = node.clone();
-                clone.x = 0.0;
-                clone.y = 0.0;
-                temp_nodes.insert(node_id.clone(), clone);
-            }
-        }
-        let local_config = subgraph_layout_config(graph, false, config);
-        let ranks = compute_ranks_subset(&sub.nodes, &graph.edges, &graph.node_order);
-        super::assign_positions(
-            &sub.nodes,
-            &ranks,
-            direction,
-            &local_config,
-            &mut temp_nodes,
-            0.0,
-            0.0,
+        // Re-place the members with the same recursive routine the anchored
+        // path uses, so a nested child keeps its own direction and stays whole
+        // instead of dissolving into this subgraph's rank graph. Keeping the
+        // existing top-left corner leaves surrounding layout undisturbed.
+        layout_cluster_contents(
+            graph,
+            idx,
+            &tree,
+            nodes,
+            theme,
+            config,
+            false,
+            (min_x, min_y),
         );
-        let mut temp_min_x = f32::MAX;
-        let mut temp_min_y = f32::MAX;
-        for node_id in &sub.nodes {
-            if let Some(node) = temp_nodes.get(node_id) {
-                temp_min_x = temp_min_x.min(node.x);
-                temp_min_y = temp_min_y.min(node.y);
-            }
-        }
-        if temp_min_x == f32::MAX {
-            continue;
-        }
-        for node_id in &sub.nodes {
-            if let (Some(target), Some(source)) = (nodes.get_mut(node_id), temp_nodes.get(node_id))
-            {
-                target.x = source.x - temp_min_x + min_x;
-                target.y = source.y - temp_min_y + min_y;
-            }
-        }
-
-        if matches!(direction, Direction::RightLeft | Direction::BottomTop) {
-            mirror_subgraph_nodes(&sub.nodes, nodes, direction);
-        }
     }
 }
 
@@ -815,9 +790,284 @@ pub(in crate::layout) fn subgraph_label_metrics(
     (label_block, padding)
 }
 
-fn estimate_subgraph_box_size(
+/// Lay out one cluster's contents, innermost first, and return the bounding box
+/// its members ended up occupying.
+///
+/// A cluster's members are stored flattened (`TOP.nodes` is `[i1,f1,i2,f2]`,
+/// not `[B1,B2]`), so ranking them directly makes nested clusters dissolve into
+/// their parent's rank graph: sibling clusters land on shared ranks and an edge
+/// written between two of them (`B1 --> B2`) is dropped, because it targets
+/// their anchors rather than any member.
+///
+/// So resolve the nesting explicitly instead. Each child cluster is laid out
+/// first, then stands in its parent's rank graph as a single unit sized to its
+/// own result; edges are rewritten onto those units. Once the parent has placed
+/// the units, each child is translated rigidly into its slot. Every cluster is
+/// therefore ranked once, with its own `direction`, over its real children.
+fn layout_cluster_contents(
+    graph: &Graph,
+    idx: usize,
+    tree: &SubgraphTree,
+    nodes: &mut BTreeMap<String, NodeLayout>,
+    theme: &Theme,
+    config: &LayoutConfig,
+    anchorable: bool,
+    origin: (f32, f32),
+) -> Option<(f32, f32, f32, f32)> {
+    let sub = graph.subgraphs.get(idx)?;
+    if sub.nodes.is_empty() {
+        return None;
+    }
+
+    let units = lay_out_child_clusters(graph, idx, tree, nodes, theme, config, anchorable);
+    let unit_ids = cluster_unit_ids(graph, sub, &units, nodes);
+    if unit_ids.is_empty() {
+        return None;
+    }
+    let unit_edges = cluster_unit_edges(graph, &units, &unit_ids);
+
+    let borrowed = insert_cluster_placeholders(graph, &units, nodes);
+    let direction = subgraph_layout_direction(graph, sub);
+    let ranks = compute_ranks_subset(
+        &unit_ids,
+        &unit_edges,
+        &cluster_unit_order(graph, &unit_ids),
+    );
+    super::assign_positions(
+        &unit_ids,
+        &ranks,
+        direction,
+        &subgraph_layout_config(graph, anchorable, config),
+        nodes,
+        origin.0,
+        origin.1,
+    );
+    if matches!(direction, Direction::RightLeft | Direction::BottomTop) {
+        mirror_subgraph_nodes(&unit_ids, nodes, direction);
+    }
+
+    let child_rects: Vec<(f32, f32, f32, f32)> = units
+        .iter()
+        .filter_map(|unit| move_child_into_slot(graph, unit, nodes))
+        .collect();
+    restore_borrowed_nodes(nodes, borrowed);
+
+    // A child's frame extends past its members by its own padding, so the
+    // parent has to contain the frames, not just the leaves.
+    let members = super::node_bounds(nodes, &sub.nodes);
+    child_rects
+        .into_iter()
+        .chain(members)
+        .reduce(|a, b| (a.0.min(b.0), a.1.min(b.1), a.2.max(b.2), a.3.max(b.3)))
+}
+
+/// A nested cluster, laid out and ready to stand in its parent's rank graph as
+/// one sized block.
+struct ClusterUnit {
+    child: usize,
+    /// Id of the hidden stand-in node placed in the parent's map.
+    id: String,
+    width: f32,
+    height: f32,
+    /// `(pad_x, pad_y, top_padding)` the child's own frame adds.
+    padding: (f32, f32, f32),
+}
+
+/// Lay each nested child out first, so it has a real size to stand in with.
+fn lay_out_child_clusters(
+    graph: &Graph,
+    idx: usize,
+    tree: &SubgraphTree,
+    nodes: &mut BTreeMap<String, NodeLayout>,
+    theme: &Theme,
+    config: &LayoutConfig,
+    anchorable: bool,
+) -> Vec<ClusterUnit> {
+    let mut units = Vec::new();
+    for &child in &tree.children[idx] {
+        let Some(bounds) = layout_cluster_contents(
+            graph,
+            child,
+            tree,
+            nodes,
+            theme,
+            config,
+            anchorable,
+            (0.0, 0.0),
+        ) else {
+            continue;
+        };
+        let padding = subgraph_label_metrics(graph, &graph.subgraphs[child], theme, config).1;
+        units.push(ClusterUnit {
+            child,
+            id: format!("__cluster_unit_{child}__"),
+            width: bounds.2 - bounds.0 + padding.0 * 2.0,
+            height: bounds.3 - bounds.1 + padding.2 + padding.1,
+            padding,
+        });
+    }
+    units
+}
+
+/// What this cluster ranks over: its own direct members, then one stand-in per
+/// nested child. A member claimed by a child belongs to that child, not here.
+fn cluster_unit_ids(
     graph: &Graph,
     sub: &crate::ir::Subgraph,
+    units: &[ClusterUnit],
+    nodes: &BTreeMap<String, NodeLayout>,
+) -> Vec<String> {
+    let claimed: HashSet<&str> = units
+        .iter()
+        .flat_map(|unit| graph.subgraphs[unit.child].nodes.iter().map(String::as_str))
+        .collect();
+    let mut ids: Vec<String> = sub
+        .nodes
+        .iter()
+        .filter(|member| !claimed.contains(member.as_str()) && nodes.contains_key(*member))
+        .cloned()
+        .collect();
+    ids.extend(units.iter().map(|unit| unit.id.clone()));
+    ids
+}
+
+/// The graph's edges rewritten onto those units, dropping any that does not
+/// touch this cluster and any that becomes a self-edge.
+///
+/// An edge may name a child cluster rather than one of its members
+/// (`B1 --> B2`). Those names are resolved from the subgraph itself: consulting
+/// the node map instead would silently drop the edge whenever the map does not
+/// happen to carry the anchor, which is exactly the case while sizing.
+fn cluster_unit_edges(
+    graph: &Graph,
+    units: &[ClusterUnit],
+    unit_ids: &[String],
+) -> Vec<crate::ir::Edge> {
+    let mut stands_for: HashMap<&str, &str> = HashMap::new();
+    for unit in units {
+        let child = &graph.subgraphs[unit.child];
+        for member in &child.nodes {
+            stands_for.insert(member.as_str(), unit.id.as_str());
+        }
+        for alias in [child.id.as_deref(), Some(child.label.as_str())]
+            .into_iter()
+            .flatten()
+        {
+            if !child.nodes.iter().any(|member| member == alias) {
+                stands_for.insert(alias, unit.id.as_str());
+            }
+        }
+    }
+    let resolve = |id: &str| -> Option<String> {
+        stands_for
+            .get(id)
+            .map(|unit| (*unit).to_string())
+            .or_else(|| unit_ids.iter().find(|known| known.as_str() == id).cloned())
+    };
+
+    let mut edges = Vec::new();
+    for edge in &graph.edges {
+        let (Some(from), Some(to)) = (resolve(&edge.from), resolve(&edge.to)) else {
+            continue;
+        };
+        if from != to {
+            let mut mapped = edge.clone();
+            mapped.from = from;
+            mapped.to = to;
+            edges.push(mapped);
+        }
+    }
+    edges
+}
+
+/// Declaration order for the units, so ranking ties break the way the source
+/// reads.
+fn cluster_unit_order(graph: &Graph, unit_ids: &[String]) -> HashMap<String, usize> {
+    unit_ids
+        .iter()
+        .enumerate()
+        .map(|(position, id)| {
+            let key = graph.node_order.get(id).copied().unwrap_or(position);
+            (id.clone(), key)
+        })
+        .collect()
+}
+
+/// Put each child into `nodes` as a hidden node of the child's own size, so the
+/// placement pass treats it as one block. Returns what to put back afterwards.
+fn insert_cluster_placeholders(
+    graph: &Graph,
+    units: &[ClusterUnit],
+    nodes: &mut BTreeMap<String, NodeLayout>,
+) -> Vec<(String, Option<NodeLayout>)> {
+    let mut borrowed = Vec::new();
+    for unit in units {
+        // Clone a real member so the stand-in carries valid defaults for every
+        // field the placement pass reads; only id/size/visibility matter here.
+        let Some(mut placeholder) = graph.subgraphs[unit.child]
+            .nodes
+            .iter()
+            .find_map(|member| nodes.get(member))
+            .cloned()
+        else {
+            continue;
+        };
+        placeholder.id = unit.id.clone();
+        placeholder.x = 0.0;
+        placeholder.y = 0.0;
+        placeholder.width = unit.width;
+        placeholder.height = unit.height;
+        placeholder.hidden = true;
+        placeholder.anchor_subgraph = None;
+        borrowed.push((unit.id.clone(), nodes.insert(unit.id.clone(), placeholder)));
+    }
+    borrowed
+}
+
+fn restore_borrowed_nodes(
+    nodes: &mut BTreeMap<String, NodeLayout>,
+    borrowed: Vec<(String, Option<NodeLayout>)>,
+) {
+    for (id, previous) in borrowed {
+        match previous {
+            Some(node) => nodes.insert(id, node),
+            None => nodes.remove(&id),
+        };
+    }
+}
+
+/// Translate a child's members rigidly from where they were laid out to the
+/// slot its stand-in ended up in, returning the rect its frame occupies.
+fn move_child_into_slot(
+    graph: &Graph,
+    unit: &ClusterUnit,
+    nodes: &mut BTreeMap<String, NodeLayout>,
+) -> Option<(f32, f32, f32, f32)> {
+    let placed = nodes.get(unit.id.as_str())?;
+    let rect = (
+        placed.x,
+        placed.y,
+        placed.x + placed.width,
+        placed.y + placed.height,
+    );
+    let (target_x, target_y) = (rect.0 + unit.padding.0, rect.1 + unit.padding.2);
+    let members = &graph.subgraphs[unit.child].nodes;
+    let (min_x, min_y, _, _) = super::node_bounds(nodes, members)?;
+    let (dx, dy) = (target_x - min_x, target_y - min_y);
+    for member in members {
+        if let Some(node) = nodes.get_mut(member) {
+            node.x += dx;
+            node.y += dy;
+        }
+    }
+    Some(rect)
+}
+
+fn estimate_subgraph_box_size(
+    graph: &Graph,
+    sub_idx: usize,
+    sub: &crate::ir::Subgraph,
+    tree: &SubgraphTree,
     nodes: &BTreeMap<String, NodeLayout>,
     theme: &Theme,
     config: &LayoutConfig,
@@ -826,7 +1076,10 @@ fn estimate_subgraph_box_size(
     if sub.nodes.is_empty() {
         return None;
     }
-    let direction = subgraph_layout_direction(graph, sub);
+    // Size the cluster with the same routine that will later place it, so the
+    // anchor standing in for it during the parent's layout is exactly the size
+    // the cluster really occupies. Anything else leaves neighbours ranked
+    // against a box that does not exist.
     let mut temp_nodes: BTreeMap<String, NodeLayout> = BTreeMap::new();
     for node_id in &sub.nodes {
         if let Some(node) = nodes.get(node_id) {
@@ -836,32 +1089,16 @@ fn estimate_subgraph_box_size(
             temp_nodes.insert(node_id.clone(), clone);
         }
     }
-    let local_config = subgraph_layout_config(graph, anchorable, config);
-    let ranks = compute_ranks_subset(&sub.nodes, &graph.edges, &graph.node_order);
-    super::assign_positions(
-        &sub.nodes,
-        &ranks,
-        direction,
-        &local_config,
+    let (min_x, min_y, max_x, max_y) = layout_cluster_contents(
+        graph,
+        sub_idx,
+        tree,
         &mut temp_nodes,
-        0.0,
-        0.0,
-    );
-    let mut min_x = f32::MAX;
-    let mut min_y = f32::MAX;
-    let mut max_x = f32::MIN;
-    let mut max_y = f32::MIN;
-    for node_id in &sub.nodes {
-        if let Some(node) = temp_nodes.get(node_id) {
-            min_x = min_x.min(node.x);
-            min_y = min_y.min(node.y);
-            max_x = max_x.max(node.x + node.width);
-            max_y = max_y.max(node.y + node.height);
-        }
-    }
-    if min_x == f32::MAX {
-        return None;
-    }
+        theme,
+        config,
+        anchorable,
+        (0.0, 0.0),
+    )?;
     let (_, (padding_x, padding_y, top_padding)) =
         subgraph_label_metrics(graph, sub, theme, config);
 
@@ -880,6 +1117,7 @@ pub(super) fn apply_subgraph_anchor_sizes(
     if graph.subgraphs.is_empty() {
         return anchors;
     }
+    let tree = SubgraphTree::build(graph);
     for (idx, sub) in graph.subgraphs.iter().enumerate() {
         if is_region_subgraph(sub) || !subgraph_should_anchor(sub, graph, nodes) {
             continue;
@@ -888,7 +1126,7 @@ pub(super) fn apply_subgraph_anchor_sizes(
             continue;
         };
         let Some((width, height, padding_x, top_padding)) =
-            estimate_subgraph_box_size(graph, sub, nodes, theme, config, true)
+            estimate_subgraph_box_size(graph, idx, sub, &tree, nodes, theme, config, true)
         else {
             continue;
         };
@@ -912,6 +1150,7 @@ pub(super) fn align_subgraphs_to_anchor_nodes(
     graph: &Graph,
     anchor_info: &HashMap<String, SubgraphAnchorInfo>,
     nodes: &mut BTreeMap<String, NodeLayout>,
+    theme: &Theme,
     config: &LayoutConfig,
 ) -> HashSet<String> {
     let mut anchored_nodes = HashSet::new();
@@ -951,6 +1190,22 @@ pub(super) fn align_subgraphs_to_anchor_nodes(
     });
 
     for (anchor_id, info) in ordered_anchors {
+        // A nested cluster is placed by its parent's recursion, as a rigid
+        // block. Re-placing it here from its own anchor -- which came from the
+        // top-level rank graph and knows nothing of the parent's interior --
+        // would tear it back out of that arrangement.
+        if tree
+            .parent
+            .get(info.sub_idx)
+            .and_then(|parent| *parent)
+            .is_some()
+        {
+            if let Some(sub) = graph.subgraphs.get(info.sub_idx) {
+                anchored_nodes.extend(sub.nodes.iter().cloned());
+            }
+            continue;
+        }
+
         let (anchor_x, anchor_y) = {
             let Some(anchor) = nodes.get(anchor_id) else {
                 continue;
@@ -960,21 +1215,16 @@ pub(super) fn align_subgraphs_to_anchor_nodes(
         let Some(sub) = graph.subgraphs.get(info.sub_idx) else {
             continue;
         };
-        let direction = subgraph_layout_direction(graph, sub);
-        let local_config = subgraph_layout_config(graph, true, config);
-        let ranks = compute_ranks_subset(&sub.nodes, &graph.edges, &graph.node_order);
-        super::assign_positions(
-            &sub.nodes,
-            &ranks,
-            direction,
-            &local_config,
+        layout_cluster_contents(
+            graph,
+            info.sub_idx,
+            &tree,
             nodes,
-            anchor_x + info.padding_x,
-            anchor_y + info.top_padding,
+            theme,
+            config,
+            true,
+            (anchor_x + info.padding_x, anchor_y + info.top_padding),
         );
-        if matches!(direction, Direction::RightLeft | Direction::BottomTop) {
-            mirror_subgraph_nodes(&sub.nodes, nodes, direction);
-        }
         anchored_nodes.extend(sub.nodes.iter().cloned());
     }
     anchored_nodes
@@ -1362,12 +1612,56 @@ pub(super) fn build_subgraph_layouts(
     theme: &Theme,
     config: &LayoutConfig,
 ) -> Vec<SubgraphLayout> {
+    let (mut subgraphs, _) = build_subgraph_layouts_indexed(graph, nodes, theme, config);
+    subgraphs.sort_by(|a, b| {
+        let area_a = a.width * a.height;
+        let area_b = b.width * b.height;
+        area_b.partial_cmp(&area_a).unwrap_or(Ordering::Equal)
+    });
+    subgraphs
+}
+
+/// The rect each subgraph will actually be drawn with, keyed by its index in
+/// `graph.subgraphs` (`None` when the subgraph has no placed member). Spacing
+/// passes need this rather than a frame's own members: a parent grows to
+/// contain its nested children, and a pass that measures only the members it
+/// declares will leave two frames overlapping.
+pub(in crate::layout) fn rendered_subgraph_rects(
+    graph: &Graph,
+    nodes: &BTreeMap<String, NodeLayout>,
+    theme: &Theme,
+    config: &LayoutConfig,
+) -> Vec<Option<[f32; 4]>> {
+    let (subgraphs, graph_to_local) = build_subgraph_layouts_indexed(graph, nodes, theme, config);
+    graph_to_local
+        .into_iter()
+        .map(|local| {
+            local.map(|local| {
+                let sub = &subgraphs[local];
+                [sub.x, sub.y, sub.x + sub.width, sub.y + sub.height]
+            })
+        })
+        .collect()
+}
+
+/// Shared body of the two above: frames in `graph.subgraphs` order, plus the
+/// index mapping that ordering implies.
+fn build_subgraph_layouts_indexed(
+    graph: &Graph,
+    nodes: &BTreeMap<String, NodeLayout>,
+    theme: &Theme,
+    config: &LayoutConfig,
+) -> (Vec<SubgraphLayout>, Vec<Option<usize>>) {
     let mut subgraphs = Vec::new();
     // Maps graph.subgraphs index -> local subgraphs index (None if skipped).
     let mut graph_to_local: Vec<Option<usize>> = Vec::with_capacity(graph.subgraphs.len());
+    // Title room each frame reserves above its contents, kept so that growing a
+    // parent around a nested child cannot swallow the parent's own title band.
+    let mut top_paddings: Vec<f32> = Vec::with_capacity(graph.subgraphs.len());
     for sub in &graph.subgraphs {
         let Some((min_x, min_y, max_x, max_y)) = super::node_bounds(nodes, &sub.nodes) else {
             graph_to_local.push(None);
+            top_paddings.push(0.0);
             continue;
         };
 
@@ -1387,6 +1681,7 @@ pub(super) fn build_subgraph_layouts(
         let extra_width = width - base_width;
 
         graph_to_local.push(Some(subgraphs.len()));
+        top_paddings.push(top_padding);
         subgraphs.push(SubgraphLayout {
             id: sub.id.clone(),
             label: sub.label.clone(),
@@ -1448,9 +1743,13 @@ pub(super) fn build_subgraph_layouts(
                     let child = &subgraphs[local_j];
                     (child.x, child.y, child.width, child.height)
                 };
+                // The top side is not free space: it carries the parent's own
+                // title. Clearing the child by `pad` there would let the child
+                // box slide up under the parent's label.
+                let top_pad = top_paddings[i].max(pad);
                 let parent = &mut subgraphs[local_i];
                 let min_x = parent.x.min(child_x - pad);
-                let min_y = parent.y.min(child_y - pad);
+                let min_y = parent.y.min(child_y - top_pad);
                 let max_x = (parent.x + parent.width).max(child_x + child_w + pad);
                 let max_y = (parent.y + parent.height).max(child_y + child_h + pad);
                 parent.x = min_x;
@@ -1461,12 +1760,7 @@ pub(super) fn build_subgraph_layouts(
         }
     }
 
-    subgraphs.sort_by(|a, b| {
-        let area_a = a.width * a.height;
-        let area_b = b.width * b.height;
-        area_b.partial_cmp(&area_a).unwrap_or(Ordering::Equal)
-    });
-    subgraphs
+    (subgraphs, graph_to_local)
 }
 
 #[cfg(test)]
@@ -1822,6 +2116,7 @@ mod tests {
         apply_subgraph_direction_overrides(
             &graph,
             &mut nodes,
+            &Theme::modern(),
             &LayoutConfig::default(),
             &HashSet::new(),
         );

--- a/src/layout/subgraphs.rs
+++ b/src/layout/subgraphs.rs
@@ -70,19 +70,7 @@ pub(super) fn apply_subgraph_bands(
         if bucket.is_empty() {
             continue;
         }
-        let mut min_x = f32::MAX;
-        let mut min_y = f32::MAX;
-        let mut max_x = f32::MIN;
-        let mut max_y = f32::MIN;
-        for node_id in bucket {
-            if let Some(node) = nodes.get(node_id) {
-                min_x = min_x.min(node.x);
-                min_y = min_y.min(node.y);
-                max_x = max_x.max(node.x + node.width);
-                max_y = max_y.max(node.y + node.height);
-            }
-        }
-        if min_x != f32::MAX {
+        if let Some((min_x, min_y, max_x, max_y)) = super::node_bounds(nodes, bucket) {
             groups.push((idx, min_x, min_y, max_x, max_y));
         }
     }
@@ -391,19 +379,9 @@ pub(super) fn apply_orthogonal_region_bands(
     for region_list in parent_map.values() {
         let mut region_boxes: Vec<(usize, f32, f32, f32, f32)> = Vec::new();
         for &region_idx in region_list {
-            let mut min_x = f32::MAX;
-            let mut min_y = f32::MAX;
-            let mut max_x = f32::MIN;
-            let mut max_y = f32::MIN;
-            for node_id in &graph.subgraphs[region_idx].nodes {
-                if let Some(node) = nodes.get(node_id) {
-                    min_x = min_x.min(node.x);
-                    min_y = min_y.min(node.y);
-                    max_x = max_x.max(node.x + node.width);
-                    max_y = max_y.max(node.y + node.height);
-                }
-            }
-            if min_x != f32::MAX {
+            if let Some((min_x, min_y, max_x, max_y)) =
+                super::node_bounds(nodes, &graph.subgraphs[region_idx].nodes)
+            {
                 region_boxes.push((region_idx, min_x, min_y, max_x, max_y));
             }
         }
@@ -557,17 +535,9 @@ pub(super) fn apply_subgraph_direction_overrides(
             continue;
         }
 
-        let mut min_x = f32::MAX;
-        let mut min_y = f32::MAX;
-        for node_id in &sub.nodes {
-            if let Some(node) = nodes.get(node_id) {
-                min_x = min_x.min(node.x);
-                min_y = min_y.min(node.y);
-            }
-        }
-        if min_x == f32::MAX {
+        let Some((min_x, min_y, _, _)) = super::node_bounds(nodes, &sub.nodes) else {
             continue;
-        }
+        };
 
         let mut temp_nodes: BTreeMap<String, NodeLayout> = BTreeMap::new();
         for node_id in &sub.nodes {
@@ -824,6 +794,27 @@ pub(super) fn subgraph_padding_from_label(
     (pad_x, pad_y, top_padding)
 }
 
+/// A subgraph's rendered title block and the padding its frame puts around its
+/// contents, as `(label_block, (pad_x, pad_y, top_padding))`.
+///
+/// An untitled subgraph measures as a zero-sized block so it gets no title
+/// band. Every caller needs that same pairing, so it lives here rather than
+/// being spelled out again at each frame-sizing site.
+pub(in crate::layout) fn subgraph_label_metrics(
+    graph: &Graph,
+    sub: &crate::ir::Subgraph,
+    theme: &Theme,
+    config: &LayoutConfig,
+) -> (TextBlock, (f32, f32, f32)) {
+    let mut label_block = measure_label(&sub.label, theme, config);
+    if sub.label.trim().is_empty() {
+        label_block.width = 0.0;
+        label_block.height = 0.0;
+    }
+    let padding = subgraph_padding_from_label(graph, sub, theme, &label_block);
+    (label_block, padding)
+}
+
 fn estimate_subgraph_box_size(
     graph: &Graph,
     sub: &crate::ir::Subgraph,
@@ -871,14 +862,8 @@ fn estimate_subgraph_box_size(
     if min_x == f32::MAX {
         return None;
     }
-    let label_empty = sub.label.trim().is_empty();
-    let mut label_block = measure_label(&sub.label, theme, config);
-    if label_empty {
-        label_block.width = 0.0;
-        label_block.height = 0.0;
-    }
-    let (padding_x, padding_y, top_padding) =
-        subgraph_padding_from_label(graph, sub, theme, &label_block);
+    let (_, (padding_x, padding_y, top_padding)) =
+        subgraph_label_metrics(graph, sub, theme, config);
 
     let width = (max_x - min_x) + padding_x * 2.0;
     let height = (max_y - min_y) + padding_y + top_padding;
@@ -1043,17 +1028,9 @@ pub(super) fn apply_state_subgraph_layouts(
         if skip_indices.contains(&idx) || sub.nodes.len() <= 1 {
             continue;
         }
-        let mut min_x = f32::MAX;
-        let mut min_y = f32::MAX;
-        for node_id in &sub.nodes {
-            if let Some(node) = nodes.get(node_id) {
-                min_x = min_x.min(node.x);
-                min_y = min_y.min(node.y);
-            }
-        }
-        if min_x == f32::MAX {
+        let Some((min_x, min_y, _, _)) = super::node_bounds(nodes, &sub.nodes) else {
             continue;
-        }
+        };
 
         let mut saved_sizes: Vec<(String, f32, f32)> = Vec::new();
         let mut inner_anchor_ids: Vec<String> = Vec::new();
@@ -1335,23 +1312,9 @@ fn mirror_subgraph_nodes(
     nodes: &mut BTreeMap<String, NodeLayout>,
     direction: Direction,
 ) {
-    let mut min_x = f32::MAX;
-    let mut min_y = f32::MAX;
-    let mut max_x = f32::MIN;
-    let mut max_y = f32::MIN;
-
-    for node_id in node_ids {
-        if let Some(node) = nodes.get(node_id) {
-            min_x = min_x.min(node.x);
-            min_y = min_y.min(node.y);
-            max_x = max_x.max(node.x + node.width);
-            max_y = max_y.max(node.y + node.height);
-        }
-    }
-
-    if min_x == f32::MAX {
+    let Some((min_x, min_y, max_x, max_y)) = super::node_bounds(nodes, node_ids) else {
         return;
-    }
+    };
 
     if matches!(direction, Direction::RightLeft) {
         for node_id in node_ids {
@@ -1403,34 +1366,15 @@ pub(super) fn build_subgraph_layouts(
     // Maps graph.subgraphs index -> local subgraphs index (None if skipped).
     let mut graph_to_local: Vec<Option<usize>> = Vec::with_capacity(graph.subgraphs.len());
     for sub in &graph.subgraphs {
-        let mut min_x = f32::MAX;
-        let mut min_y = f32::MAX;
-        let mut max_x = f32::MIN;
-        let mut max_y = f32::MIN;
-
-        for node_id in &sub.nodes {
-            if let Some(node) = nodes.get(node_id) {
-                min_x = min_x.min(node.x);
-                min_y = min_y.min(node.y);
-                max_x = max_x.max(node.x + node.width);
-                max_y = max_y.max(node.y + node.height);
-            }
-        }
-
-        if min_x == f32::MAX {
+        let Some((min_x, min_y, max_x, max_y)) = super::node_bounds(nodes, &sub.nodes) else {
             graph_to_local.push(None);
             continue;
-        }
+        };
 
         let style = resolve_subgraph_style(sub, graph);
-        let mut label_block = measure_label(&sub.label, theme, config);
         let label_empty = sub.label.trim().is_empty();
-        if label_empty {
-            label_block.width = 0.0;
-            label_block.height = 0.0;
-        }
-        let (padding_x, padding_y, top_padding) =
-            subgraph_padding_from_label(graph, sub, theme, &label_block);
+        let (label_block, (padding_x, padding_y, top_padding)) =
+            subgraph_label_metrics(graph, sub, theme, config);
 
         let node_width = max_x - min_x;
         let base_width = node_width + padding_x * 2.0;

--- a/src/render.rs
+++ b/src/render.rs
@@ -6152,6 +6152,12 @@ fn edge_decoration_svg(
 }
 
 fn arrowhead_svg(point: (f32, f32), angle_deg: f32, stroke: &str, stroke_width: f32) -> String {
+    // `linkStyle ... stroke-width:0px` hides an edge; the arrowhead is a
+    // filled polygon rather than a stroked marker, so without this it would
+    // keep painting at the clamped minimum size and leave a stray tick behind.
+    if stroke_width <= 0.0 {
+        return String::new();
+    }
     let size = (stroke_width * 1.5 + 4.5).clamp(5.5, 10.0);
     let half = size * 0.52;
     let (x, y) = point;

--- a/tests/layout_suite.rs
+++ b/tests/layout_suite.rs
@@ -970,6 +970,118 @@ fn sankey_scc_member_order_follows_declaration_order_deterministically() {
     assert!(first["D"] > first["C"] && reordered["D"] > reordered["B"]);
 }
 
+/// Three frames of three stacked rows each, chained through their middle rows.
+fn three_stacked_frames_input() -> String {
+    let frames: String = ["A", "B", "C"]
+        .iter()
+        .map(|c| {
+            format!(
+                "  subgraph F{c}[\"frame {c}\"]\n    {c}1[\"row one\"]\n    {c}2[\"row two\"]\n\
+                     {c}3[\"row three\"]\n    {c}1 --- {c}2\n    {c}2 --- {c}3\n  end\n"
+            )
+        })
+        .collect();
+    format!("flowchart TB\n{frames}  A2 --> B2\n  B2 --> C2\n")
+}
+
+/// Chained subgraphs must stack in edge order, and that order must not depend
+/// on how tall the frame titles happen to render.
+///
+/// Ranking is subgraph-blind, so `B1`/`C1` (no incoming edge) used to land on
+/// rank 0 beside `A1`, leaving all three frames overlapping. The pass that
+/// pulled them apart then sorted on a bound that included the title padding,
+/// so a two-line title reordered the frames: here `foo()` is the only one-line
+/// title, which was enough to sink it below `main()`.
+#[test]
+fn chained_subgraphs_stack_in_edge_order_regardless_of_title_height() {
+    fn frame_tops(titles: [&str; 3]) -> [f32; 3] {
+        let [ta, tb, tc] = titles;
+        let input = format!(
+            "flowchart TB\n\
+             subgraph FA[\"{ta}\"]\n A1[\"a one\"]\n A2[\"a two\"]\n A3[\"a three\"]\n A1 --- A2\n A2 --- A3\n end\n\
+             subgraph FB[\"{tb}\"]\n B1[\"b one\"]\n B2[\"b two\"]\n B3[\"b three\"]\n B1 --- B2\n B2 --- B3\n end\n\
+             subgraph FC[\"{tc}\"]\n C1[\"c one\"]\n C2[\"c two\"]\n C3[\"c three\"]\n C1 --- C2\n C2 --- C3\n end\n\
+             A2 --> B2\n B2 --> C2\n"
+        );
+        let parsed = parse_mermaid(&input).expect("parse failed");
+        let layout = compute_layout(&parsed.graph, &Theme::modern(), &LayoutConfig::default());
+        ["A", "B", "C"].map(|frame| {
+            (1..=3)
+                .map(|row| {
+                    let id = format!("{frame}{row}");
+                    layout.nodes.get(&id).unwrap_or_else(|| panic!("{id}")).y
+                })
+                .fold(f32::MAX, f32::min)
+        })
+    }
+
+    // The title lengths that originally broke it: only the middle frame fits
+    // on one line.
+    let uneven = frame_tops([
+        "baz() — innermost, lowest address",
+        "foo()",
+        "main() — outermost, highest address",
+    ]);
+    let even = frame_tops(["baz()", "foo()", "main()"]);
+
+    for (case, tops) in [("uneven titles", uneven), ("even titles", even)] {
+        assert!(
+            tops[0] < tops[1] && tops[1] < tops[2],
+            "{case}: frames must stack A -> B -> C, got tops {tops:?}"
+        );
+    }
+
+    // Each frame owns a contiguous rank band, so no two frames interleave.
+    let parsed = parse_mermaid(
+        "flowchart TB\n\
+         subgraph FA[\"one\"]\n A1 --- A2\n end\n\
+         subgraph FB[\"two\"]\n B1 --- B2\n end\n\
+         A2 --> B2\n",
+    )
+    .expect("parse failed");
+    let layout = compute_layout(&parsed.graph, &Theme::modern(), &LayoutConfig::default());
+    let bottom_of_a = ["A1", "A2"]
+        .iter()
+        .map(|id| {
+            let node = layout.nodes.get(*id).expect("node");
+            node.y + node.height
+        })
+        .fold(f32::MIN, f32::max);
+    let top_of_b = ["B1", "B2"]
+        .iter()
+        .map(|id| layout.nodes.get(*id).expect("node").y)
+        .fold(f32::MAX, f32::min);
+    assert!(
+        bottom_of_a < top_of_b,
+        "frames must occupy disjoint rank bands, got A bottom {bottom_of_a} vs B top {top_of_b}"
+    );
+
+    // Rank bands also have to keep each frame's rows in one column. When the
+    // frames share ranks instead, a row is placed as a sibling of the *other*
+    // frames' rows and is dragged far across the diagram -- the frames still
+    // stack, but their contents scatter.
+    let parsed = parse_mermaid(&three_stacked_frames_input()).expect("parse failed");
+    let layout = compute_layout(&parsed.graph, &Theme::modern(), &LayoutConfig::default());
+    for frame in ["A", "B", "C"] {
+        let centres: Vec<f32> = (1..=3)
+            .map(|row| {
+                let id = format!("{frame}{row}");
+                let node = layout.nodes.get(&id).unwrap_or_else(|| panic!("{id}"));
+                node.x + node.width * 0.5
+            })
+            .collect();
+        let spread = centres.iter().fold(f32::MIN, |a, b| a.max(*b))
+            - centres.iter().fold(f32::MAX, |a, b| a.min(*b));
+        let widest = (1..=3)
+            .map(|row| layout.nodes[&format!("{frame}{row}")].width)
+            .fold(f32::MIN, f32::max);
+        assert!(
+            spread <= widest * 0.5,
+            "frame {frame} rows must stay in one column, centres {centres:?} spread {spread:.1}px for rows at most {widest:.1}px wide"
+        );
+    }
+}
+
 #[test]
 fn bidirectional_flowchart_labels_do_not_overlap() {
     let input = r#"flowchart TD

--- a/tests/layout_suite.rs
+++ b/tests/layout_suite.rs
@@ -1082,6 +1082,57 @@ fn chained_subgraphs_stack_in_edge_order_regardless_of_title_height() {
     }
 }
 
+/// An edge between stacked frames must use the free channel beside them rather
+/// than climbing back over the source frame.
+///
+/// When a wide neighbour sits directly below the source and another directly
+/// above the target, every opposite-side port pairing is obstructed. The side
+/// search used to offer only those, so it picked the least-broken one: the
+/// route left `A2` rightward, climbed above the whole first frame, crossed to
+/// the far left, then dropped ~475px. Same-flank ports make it a straight drop.
+#[test]
+fn edges_between_stacked_frames_do_not_backtrack_over_the_source() {
+    let parsed = parse_mermaid(&three_stacked_frames_input()).expect("parse failed");
+    let layout = compute_layout(&parsed.graph, &Theme::modern(), &LayoutConfig::default());
+
+    for (from, to) in [("A2", "B2"), ("B2", "C2")] {
+        let edge = layout
+            .edges
+            .iter()
+            .find(|edge| edge.from == from && edge.to == to)
+            .unwrap_or_else(|| panic!("{from}->{to} edge"));
+
+        // In a TB flowchart a forward edge should never climb back up.
+        let backtrack: f32 = edge
+            .points
+            .windows(2)
+            .map(|seg| (seg[0].1 - seg[1].1).max(0.0))
+            .sum();
+        assert!(
+            backtrack <= 1.0,
+            "{from}->{to} climbs {backtrack:.1}px back up the diagram: {:?}",
+            edge.points
+        );
+
+        // The old route wandered far wider than the nodes it connects.
+        let from_node = layout.nodes.get(from).expect("source node");
+        let to_node = layout.nodes.get(to).expect("target node");
+        let widest = from_node.width.max(to_node.width);
+        let span = edge
+            .points
+            .iter()
+            .fold((f32::MAX, f32::MIN), |(lo, hi), p| {
+                (lo.min(p.0), hi.max(p.0))
+            });
+        assert!(
+            span.1 - span.0 <= widest,
+            "{from}->{to} spans {:.1}px horizontally for nodes only {widest:.1}px wide: {:?}",
+            span.1 - span.0,
+            edge.points
+        );
+    }
+}
+
 #[test]
 fn bidirectional_flowchart_labels_do_not_overlap() {
     let input = r#"flowchart TD

--- a/tests/layout_suite.rs
+++ b/tests/layout_suite.rs
@@ -1752,3 +1752,119 @@ fn multiple_state_notes_on_one_side_search_outward() {
     assert!(second.x > first.x, "later right note should move outward");
     assert!(second.x + second.width <= layout.width);
 }
+
+/// Conformance contract for nested subgraph layout, derived from mermaid's own
+/// rendering of the canonical nested-direction example (docs/flowchart syntax).
+///
+/// Cluster geometry used to be derived independently in several places, each
+/// re-ranking the *flattened* member list from a different origin, so they
+/// disagreed. It now comes from one recursive routine that sizes a cluster
+/// once, applies its `direction` once, and places it into its parent as a
+/// rigid sized block.
+#[test]
+fn nested_subgraph_layout_contract() {
+    let input = r#"flowchart LR
+  subgraph TOP
+    direction TB
+    subgraph B1
+        direction RL
+        i1 -->f1
+    end
+    subgraph B2
+        direction BT
+        i2 -->f2
+    end
+  end
+  A --> TOP --> B
+  B1 --> B2
+"#;
+    let parsed = parse_mermaid(input).expect("parse failed");
+    let layout = compute_layout(&parsed.graph, &Theme::modern(), &LayoutConfig::default());
+
+    let raw_sg = |label: &str| {
+        layout
+            .subgraphs
+            .iter()
+            .find(|s| s.label == label)
+            .unwrap_or_else(|| panic!("subgraph {label}"))
+    };
+    let sg = |label: &str| {
+        let s = raw_sg(label);
+        (s.x, s.y, s.x + s.width, s.y + s.height)
+    };
+    let nd = |id: &str| {
+        let n = layout.nodes.get(id).unwrap_or_else(|| panic!("node {id}"));
+        (n.x, n.y, n.x + n.width, n.y + n.height)
+    };
+    let inside = |i: (f32, f32, f32, f32), o: (f32, f32, f32, f32)| {
+        i.0 >= o.0 - 0.5 && i.1 >= o.1 - 0.5 && i.2 <= o.2 + 0.5 && i.3 <= o.3 + 0.5
+    };
+    let cy = |b: (f32, f32, f32, f32)| (b.1 + b.3) * 0.5;
+
+    let (top, b1, b2) = (sg("TOP"), sg("B1"), sg("B2"));
+    let (a, b) = (nd("A"), nd("B"));
+
+    // Parent flow is LR: A, then the TOP cluster as a unit, then B.
+    assert!(a.2 <= top.0, "A must sit entirely left of TOP");
+    assert!(top.2 <= b.0, "TOP must sit entirely left of B");
+
+    // A cluster behaves as one sized node, so its neighbours centre on it.
+    assert!((cy(a) - cy(top)).abs() <= 20.0, "A must be centred on TOP");
+    assert!((cy(b) - cy(top)).abs() <= 20.0, "B must be centred on TOP");
+
+    // TOP's own `direction TB` orders its children as whole blocks.
+    assert!(b1.3 <= b2.1, "TOP direction TB must put B1 above B2");
+
+    // Containment holds at every level.
+    assert!(inside(b1, top) && inside(b2, top), "children inside TOP");
+
+    // A parent's title band belongs to the parent: a nested child box starts
+    // below it, so the two labels never collide. Mermaid leaves 37.5px here.
+    let top_title = raw_sg("TOP").label_block.height;
+    assert!(
+        b1.1 - top.1 >= top_title,
+        "TOP's title band ({:.1}px) must clear B1's box, which starts {:.1}px below TOP",
+        top_title,
+        b1.1 - top.1
+    );
+
+    // Sibling clusters joined by an edge centre on each other along the parent's
+    // cross axis, exactly as two connected plain nodes would.
+    let cx = |b: (f32, f32, f32, f32)| (b.0 + b.2) * 0.5;
+    assert!(
+        (cx(b1) - cx(b2)).abs() <= 2.0,
+        "B1 and B2 must be centre-aligned in TOP's TB flow, got {:.1} vs {:.1}",
+        cx(b1),
+        cx(b2)
+    );
+    assert!(inside(nd("i1"), b1) && inside(nd("f1"), b1), "leaves in B1");
+    assert!(inside(nd("i2"), b2) && inside(nd("f2"), b2), "leaves in B2");
+
+    // Innermost directions still apply within their own cluster.
+    assert!(nd("f1").2 <= nd("i1").0, "B1 direction RL: f1 left of i1");
+    assert!(nd("f2").3 <= nd("i2").1, "B2 direction BT: f2 above i2");
+
+    // An edge between sibling clusters stays in their parent and flows with it.
+    let edge = layout
+        .edges
+        .iter()
+        .find(|e| e.from == "B1" && e.to == "B2")
+        .expect("B1->B2 edge");
+    let (min_x, max_x) = edge
+        .points
+        .iter()
+        .fold((f32::MAX, f32::MIN), |(lo, hi), p| {
+            (lo.min(p.0), hi.max(p.0))
+        });
+    assert!(
+        min_x >= top.0 - 2.0 && max_x <= top.2 + 2.0,
+        "B1->B2 must stay within TOP, got x {min_x:.1}..{max_x:.1} vs TOP {:.1}..{:.1}",
+        top.0,
+        top.2
+    );
+    assert!(
+        edge.points.windows(2).all(|s| s[1].1 >= s[0].1 - 1.0),
+        "B1->B2 must flow downward with TOP's TB direction: {:?}",
+        edge.points
+    );
+}


### PR DESCRIPTION
 This is broken

  ```
  flowchart LR
    subgraph TOP
      direction TB
      subgraph B1
          direction RL
          i1 -->f1
      end
      subgraph B2
          direction BT
          i2 -->f2
      end
    end
    A --> TOP --> B
    B1 --> B2
  ```

  - A and B sat above TOP instead of beside it.
  - TOP's direction TB was ignored — B1 and B2 placed side by side.
  - B1 --> B2 looped around the outside of the diagram.
  - TOP's title was drawn on top of B1's box.
  - Chained subgraphs overlapped, their rows scattered, and title height decided which frame landed on top.
  - Edges between stacked frames backtracked over the source frame.
  - -o diagram.png wrote SVG bytes into a .png.
  - linkStyle stroke-width:0px left a stray arrowhead behind.

  How it is fixed

  - One recursive layout_cluster_contents replaces the four passes that each re-ranked a cluster's flattened member list from a different origin.
  - Ranks are centred rather than edge-aligned; a parent frame keeps its title band above a nested child; sibling separation measures the rect that gets drawn.
  - Ranking-only edges between chained frames put each frame in its own band, and frame order sorts on the unpadded member bound.
  - A same-flank port pairing is offered to edges that cross a frame boundary.
  - Output format falls back to the output file's extension.
  - No arrowhead is emitted when the stroke width is not positive.

  A separate no-behaviour-change commit extracts node_bounds and subgraph_label_metrics, which the layout fixes then build on.